### PR TITLE
feat: 채팅테이블 스키마 반영, 웹소켓 기본 세팅, 웹소켓테스트(#6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "nodemon": "^3.1.11",
+        "socket.io": "^4.8.3",
         "tsoa": "^7.0.0-alpha.0"
       },
       "devDependencies": {
@@ -2759,6 +2760,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -3217,6 +3224,15 @@
         "@types/connect": "*",
         "@types/express": "*",
         "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -3957,6 +3973,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -4469,6 +4494,19 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -4699,6 +4737,78 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
+      "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/error-ex": {
@@ -8022,6 +8132,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -8454,9 +8573,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8814,6 +8933,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/source-map": {
@@ -9778,6 +9981,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "nodemon": "^3.1.11",
+    "socket.io": "^4.8.3",
     "tsoa": "^7.0.0-alpha.0"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,25 +28,76 @@ model category {
   reform_request  reform_request[]
 }
 
-model chat_message {
-  message_id   String    @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  chat_room_id String    @db.Uuid
-  created_at   DateTime? @default(now()) @db.Timestamp(6)
-  Field        String?   @db.VarChar(255)
-  chat_room    chat_room @relation(fields: [chat_room_id], references: [chat_room_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_chat_room_TO_chat_message_1")
+model chat_room {
+  chat_room_id           String         @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  owner_id               String         @db.Uuid
+  requester_id           String         @db.Uuid
+  requester_last_read_id String?        @db.Uuid
+  owner_last_read_id     String?        @db.Uuid
+  last_message_id        String?        @db.Uuid
+  target_payload         Json?          @db.JsonB
+  is_active              Boolean        @default(true)
+  created_at             DateTime?      @default(now()) @db.Timestamp(6)
+  updated_at             DateTime?      @default(now()) @updatedAt @db.Timestamp(6)
 
-  @@index([chat_room_id], map: "idx_chat_message_room")
+  owner                  owner          @relation(fields: [owner_id], references: [owner_id], onDelete: NoAction, onUpdate: NoAction)
+  requester              user           @relation(fields: [requester_id], references: [user_id], onDelete: NoAction, onUpdate: NoAction)
+  messages               chat_message[]
+
+  @@index([owner_id])
+  @@index([requester_id])
 }
 
-model chat_room {
-  chat_room_id String                 @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  user_id      String?                @db.Uuid
-  owner_id     String?                @db.Uuid
-  target_type  chat_target_type_enum?
-  target_id    String?                @db.Uuid
-  created_at   DateTime?              @default(now()) @db.Timestamp(6)
-  updated_at   DateTime?              @default(now()) @db.Timestamp(6)
-  chat_message chat_message[]
+model chat_message {
+  message_id    String        @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  chat_room_id  String        @db.Uuid
+  sender_id     String?       @db.Uuid
+  sender_type   sender_type?
+  message_type  message_type?
+  text_content  String?       @db.Text
+  payload       Json?         @db.JsonB
+  created_at    DateTime?     @default(now()) @db.Timestamp(6)
+  updated_at    DateTime?     @default(now()) @updatedAt @db.Timestamp(6)
+
+  chat_room     chat_room     @relation(fields: [chat_room_id], references: [chat_room_id], onDelete: Cascade)
+  
+  chat_request  chat_request[]
+  chat_proposal chat_proposal[]
+
+  @@index([chat_room_id])
+}
+
+model chat_request {
+  chat_request_id String       @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  message_id      String       @db.Uuid
+  title           String?
+  image           String[]     @default([])
+  content         String?      @db.Text
+  min_budget      Int?
+  max_budget      Int?
+  created_at      DateTime?    @default(now()) @db.Timestamp(6)
+  updated_at      DateTime?    @default(now()) @updatedAt @db.Timestamp(6)
+
+  message         chat_message @relation(fields: [message_id], references: [message_id], onDelete: Cascade)
+
+  @@index([message_id])
+}
+
+model chat_proposal {
+  chat_proposal_id String       @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  message_id       String       @db.Uuid
+  is_accepted      Boolean      @default(false)
+  title            String?
+  price            Int?
+  delivery         Int?
+  expected_working Int?
+  image            String[]     @default([])
+  created_at       DateTime?    @default(now()) @db.Timestamp(6)
+  updated_at       DateTime?    @default(now()) @updatedAt @db.Timestamp(6)
+
+  message          chat_message @relation(fields: [message_id], references: [message_id], onDelete: Cascade)
+
+  @@index([message_id])
 }
 
 model delivery_address {
@@ -66,6 +117,7 @@ model feed {
   owner_id   String       @db.Uuid
   created_at DateTime?    @default(now()) @db.Timestamp(6)
   updated_at DateTime?    @default(now()) @db.Timestamp(6)
+  is_pinned  Boolean?     @default(false)
   owner      owner        @relation(fields: [owner_id], references: [owner_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_owner_TO_feed_1")
   feed_photo feed_photo[]
 }
@@ -85,12 +137,13 @@ model item {
   title        String?        @db.VarChar(50)
   content      String?
   price        Decimal?       @db.Decimal
-  quantity     Int?
   delivery     Decimal?       @db.Decimal
   created_at   DateTime?      @default(now()) @db.Timestamp(6)
   updated_at   DateTime?      @default(now()) @db.Timestamp(6)
   owner_id     String         @db.Uuid
   category_id  String         @db.Uuid
+  avg_star     Decimal?       @db.Decimal
+  review_count Int?
   category     category       @relation(fields: [category_id], references: [category_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_category_TO_item_1")
   owner        owner          @relation(fields: [owner_id], references: [owner_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_owner_TO_item_1")
   item_photo   item_photo[]
@@ -126,6 +179,7 @@ model option_item {
   name            String?        @db.VarChar(100)
   extra_price     Int?
   sort_order      Int?
+  quantity        Int?
   option_group    option_group   @relation(fields: [option_group_id], references: [option_group_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_option_group_TO_option_item_1")
   order_option    order_option[]
 }
@@ -167,22 +221,32 @@ model order_option {
 }
 
 model owner {
-  owner_id         String             @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  email            String?            @db.VarChar(30)
-  hashed           String?            @db.VarChar(256)
-  salt             String?            @db.VarChar(256)
-  name             String?            @db.VarChar(50)
-  nickname         String?            @db.VarChar(50)
-  phone            String?            @db.VarChar(50)
-  created_at       DateTime?          @default(now()) @db.Timestamp(6)
-  updated_at       DateTime?          @default(now()) @db.Timestamp(6)
-  delivery_address delivery_address[]
-  feed             feed[]
-  item             item[]
-  order            order[]
-  owner_wish       owner_wish[]
-  reform_proposal  reform_proposal[]
-  reformer_auth    reformer_auth[]
+  owner_id          String               @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  email             String?              @db.VarChar(30)
+  hashed            String?              @db.VarChar(256)
+  name              String?              @db.VarChar(50)
+  nickname          String?              @unique(map: "owner_nickname_unique") @db.VarChar(50)
+  phone             String?              @db.VarChar(50)
+  created_at        DateTime?            @default(now()) @db.Timestamp(6)
+  updated_at        DateTime?            @default(now()) @db.Timestamp(6)
+  age_confirmed_at  DateTime             @default(now()) @db.Timestamp(6)
+  terms_agreed_at   DateTime             @default(now()) @db.Timestamp(6)
+  privacy_opt_in_at DateTime?            @db.Timestamp(6)
+  status            reformer_status_enum @default(PENDING)
+  profile_photo     String?              @db.VarChar(256)
+  bio               String?
+  keywords          String[]             @default([])
+  avg_star          Decimal?             @db.Decimal
+  review_count      Int?
+  trade_count       Int?
+  delivery_address  delivery_address[]
+  feed              feed[]
+  item              item[]
+  order             order[]
+  owner_wish        owner_wish[]
+  reform_proposal   reform_proposal[]
+  reformer_auth     reformer_auth[]
+  chat_rooms        chat_room[]
 }
 
 model owner_wish {
@@ -217,6 +281,8 @@ model reform_proposal {
   updated_at            DateTime?               @default(now()) @db.Timestamp(6)
   owner_id              String                  @db.Uuid
   category_id           String                  @db.Uuid
+  avg_star              Decimal?                @db.Decimal
+  review_count          Int?
   category              category                @relation(fields: [category_id], references: [category_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_category_TO_reform_proposal_1")
   owner                 owner                   @relation(fields: [owner_id], references: [owner_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_owner_TO_reform_proposal_1")
   reform_proposal_photo reform_proposal_photo[]
@@ -306,20 +372,24 @@ model review_photo {
 }
 
 model user {
-  user_id          String             @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  email            String?            @db.VarChar(30)
-  hashed           String?            @db.VarChar(256)
-  salt             String?            @db.VarChar(256)
-  name             String?            @db.VarChar(50)
-  nickname         String?            @db.VarChar(50)
-  phone            String?            @db.VarChar(50)
-  created_at       DateTime?          @default(now()) @db.Timestamp(6)
-  updated_at       DateTime?          @default(now()) @db.Timestamp(6)
-  cart             cart[]
-  delivery_address delivery_address[]
-  order            order[]
-  reform_request   reform_request[]
-  user_wish        user_wish[]
+  user_id           String             @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  email             String?            @db.VarChar(30)
+  hashed            String?            @db.VarChar(256)
+  name              String?            @db.VarChar(50)
+  nickname          String?            @unique(map: "user_nickname_unique") @db.VarChar(50)
+  phone             String?            @db.VarChar(50)
+  created_at        DateTime?          @default(now()) @db.Timestamp(6)
+  updated_at        DateTime?          @default(now()) @db.Timestamp(6)
+  age_confirmed_at  DateTime           @default(now()) @db.Timestamp(6)
+  terms_agreed_at   DateTime           @default(now()) @db.Timestamp(6)
+  privacy_opt_in_at DateTime?          @db.Timestamp(6)
+  profile_photo     String?            @db.VarChar(256)
+  cart              cart[]
+  delivery_address  delivery_address[]
+  order             order[]
+  reform_request    reform_request[]
+  user_wish         user_wish[]
+  chat_rooms        chat_room[]
 }
 
 model user_wish {
@@ -328,6 +398,29 @@ model user_wish {
   target_id   String?           @db.Uuid
   user_id     String            @db.Uuid
   user        user              @relation(fields: [user_id], references: [user_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_user_TO_user_wish_1")
+}
+
+model banner {
+  banner_id  String    @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  image_url  String    @db.VarChar(256)
+  link       String?   @db.VarChar(256)
+  sort_order Int?      @default(0)
+  is_active  Boolean?  @default(true)
+  created_at DateTime? @default(now()) @db.Timestamp(6)
+  updated_at DateTime? @default(now()) @db.Timestamp(6)
+}
+
+model social_account {
+  social_account_id String        @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  provider          provider_type
+  provider_id       String
+  role              account_role
+  user_id           String?       @db.Uuid
+  owner_id          String?       @db.Uuid
+
+  @@unique([owner_id, provider], map: "social_account_owner_provider_key")
+  @@unique([provider, provider_id, role], map: "social_account_provider_identity_key")
+  @@unique([user_id, provider], map: "social_account_user_provider_key")
 }
 
 enum chat_target_type_enum {
@@ -351,4 +444,35 @@ enum target_type_enum {
   REQUEST
   PROPOSAL
   ITEM
+}
+
+enum sender_type {
+  USER
+  OWNER
+}
+
+enum account_role {
+  USER
+  OWNER
+}
+
+enum provider_type {
+  GOOGLE
+  KAKAO
+  APPLE
+}
+
+enum reformer_status_enum {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+enum message_type {
+  image
+  request
+  proposal
+  text
+  payment
+  result
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,38 +31,35 @@ model category {
 model chat_room {
   chat_room_id           String         @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   owner_id               String         @db.Uuid
-  requester_id           String         @db.Uuid
-  requester_last_read_id String?        @db.Uuid
-  owner_last_read_id     String?        @db.Uuid
-  last_message_id        String?        @db.Uuid
-  target_payload         Json?          @db.JsonB
-  is_active              Boolean        @default(true)
   created_at             DateTime?      @default(now()) @db.Timestamp(6)
   updated_at             DateTime?      @default(now()) @updatedAt @db.Timestamp(6)
-
+  is_active              Boolean        @default(true)
+  last_message_id        String?        @db.Uuid
+  owner_last_read_id     String?        @db.Uuid
+  requester_id           String         @db.Uuid
+  requester_last_read_id String?        @db.Uuid
+  target_payload         Json?
+  messages               chat_message[]
   owner                  owner          @relation(fields: [owner_id], references: [owner_id], onDelete: NoAction, onUpdate: NoAction)
   requester              user           @relation(fields: [requester_id], references: [user_id], onDelete: NoAction, onUpdate: NoAction)
-  messages               chat_message[]
 
   @@index([owner_id])
   @@index([requester_id])
 }
 
 model chat_message {
-  message_id    String        @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  chat_room_id  String        @db.Uuid
-  sender_id     String?       @db.Uuid
-  sender_type   sender_type?
+  message_id    String          @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  chat_room_id  String          @db.Uuid
+  created_at    DateTime?       @default(now()) @db.Timestamp(6)
   message_type  message_type?
-  text_content  String?       @db.Text
-  payload       Json?         @db.JsonB
-  created_at    DateTime?     @default(now()) @db.Timestamp(6)
-  updated_at    DateTime?     @default(now()) @updatedAt @db.Timestamp(6)
-
-  chat_room     chat_room     @relation(fields: [chat_room_id], references: [chat_room_id], onDelete: Cascade)
-  
-  chat_request  chat_request[]
+  payload       Json?
+  sender_id     String?         @db.Uuid
+  sender_type   sender_type?
+  text_content  String?
+  updated_at    DateTime?       @default(now()) @updatedAt @db.Timestamp(6)
+  chat_room     chat_room       @relation(fields: [chat_room_id], references: [chat_room_id], onDelete: Cascade)
   chat_proposal chat_proposal[]
+  chat_request  chat_request[]
 
   @@index([chat_room_id])
 }
@@ -72,12 +69,11 @@ model chat_request {
   message_id      String       @db.Uuid
   title           String?
   image           String[]     @default([])
-  content         String?      @db.Text
+  content         String?
   min_budget      Int?
   max_budget      Int?
   created_at      DateTime?    @default(now()) @db.Timestamp(6)
   updated_at      DateTime?    @default(now()) @updatedAt @db.Timestamp(6)
-
   message         chat_message @relation(fields: [message_id], references: [message_id], onDelete: Cascade)
 
   @@index([message_id])
@@ -94,7 +90,6 @@ model chat_proposal {
   image            String[]     @default([])
   created_at       DateTime?    @default(now()) @db.Timestamp(6)
   updated_at       DateTime?    @default(now()) @updatedAt @db.Timestamp(6)
-
   message          chat_message @relation(fields: [message_id], references: [message_id], onDelete: Cascade)
 
   @@index([message_id])
@@ -230,15 +225,16 @@ model owner {
   created_at        DateTime?            @default(now()) @db.Timestamp(6)
   updated_at        DateTime?            @default(now()) @db.Timestamp(6)
   age_confirmed_at  DateTime             @default(now()) @db.Timestamp(6)
-  terms_agreed_at   DateTime             @default(now()) @db.Timestamp(6)
-  privacy_opt_in_at DateTime?            @db.Timestamp(6)
-  status            reformer_status_enum @default(PENDING)
-  profile_photo     String?              @db.VarChar(256)
+  avg_star          Decimal?             @db.Decimal
   bio               String?
   keywords          String[]             @default([])
-  avg_star          Decimal?             @db.Decimal
+  privacy_opt_in_at DateTime?            @db.Timestamp(6)
+  profile_photo     String?              @db.VarChar(256)
   review_count      Int?
+  status            reformer_status_enum @default(PENDING)
+  terms_agreed_at   DateTime             @default(now()) @db.Timestamp(6)
   trade_count       Int?
+  chat_rooms        chat_room[]
   delivery_address  delivery_address[]
   feed              feed[]
   item              item[]
@@ -246,7 +242,6 @@ model owner {
   owner_wish        owner_wish[]
   reform_proposal   reform_proposal[]
   reformer_auth     reformer_auth[]
-  chat_rooms        chat_room[]
 }
 
 model owner_wish {
@@ -381,15 +376,15 @@ model user {
   created_at        DateTime?          @default(now()) @db.Timestamp(6)
   updated_at        DateTime?          @default(now()) @db.Timestamp(6)
   age_confirmed_at  DateTime           @default(now()) @db.Timestamp(6)
-  terms_agreed_at   DateTime           @default(now()) @db.Timestamp(6)
   privacy_opt_in_at DateTime?          @db.Timestamp(6)
   profile_photo     String?            @db.VarChar(256)
+  terms_agreed_at   DateTime           @default(now()) @db.Timestamp(6)
   cart              cart[]
+  chat_rooms        chat_room[]
   delivery_address  delivery_address[]
   order             order[]
   reform_request    reform_request[]
   user_wish         user_wish[]
-  chat_rooms        chat_room[]
 }
 
 model user_wish {

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import * as swaggerUI from 'swagger-ui-express';
 import { RegisterRoutes } from './routes/tsoaRoutes.js';
 import dotenv from 'dotenv';
 import { errorHandler, notFoundHandler } from './middleware/error.js';
+import { WebSocketServer } from './infra/websocket/websocket.js';
 
 dotenv.config();
 const app = express();
@@ -18,4 +19,8 @@ app.use('/docs', swaggerUI.serve, swaggerUI.setup(swaggerJson));
 app.use(notFoundHandler);
 app.use(errorHandler);
 
-app.listen(3001);
+const server = app.listen(3001);
+
+// 웹소켓 서버 초기화
+const webSocketServer = WebSocketServer.getInstance();
+webSocketServer.init(server);

--- a/src/infra/websocket/chat.ts
+++ b/src/infra/websocket/chat.ts
@@ -1,0 +1,56 @@
+import { Server, Socket } from 'socket.io';
+import { WebSocketServer } from './websocket.js';
+
+export function setupChatEventHandlers(io: Server, socket: Socket): void {
+  const socketId = socket.id;
+  const roomId = socket.handshake.headers.roomid as string;
+  const userMap = WebSocketServer.getInstance().userMap;
+
+  if (roomId) {
+    // 해당 방이 없으면 새로 만들고, 있으면 기존 배열에 추가
+    if (!userMap.has(roomId)) {
+      userMap.set(roomId, []);
+    }
+    userMap.get(roomId)?.push(socketId);
+        
+    void socket.join(`user-${socketId}`); 
+    console.log(`[연결] 방: ${roomId}, 소켓: ${socketId} 추가됨`);
+  }
+
+  // 메시지 수신 핸들러
+  socket.on('sendMessage', (data: { roomId: string, message: string }) => {
+    console.log(`[수신] ${socketId} -> 방 ${data.roomId}: ${data.message}`);
+    const { roomId, message } = data;
+    const targetIds = userMap.get(roomId);
+
+    if (targetIds) {
+      // 방에 참여한 상대방에게 메시지 전송
+      targetIds.forEach((receiverId) => {
+        if (receiverId !== socketId) {
+          io.to(`user-${receiverId}`).emit('receiveMessage', {
+            roomId,
+            message,
+            sender: socketId
+          });
+          console.log(`[전송] ${socketId} -> ${receiverId} (${roomId})`);
+        }
+      });
+    }
+  });
+
+  // 연결 해제 시 배열에서 제거
+  socket.on('disconnect', () => {
+    const targetIds = userMap.get(roomId);
+    if (targetIds) {
+      const index = targetIds.indexOf(socketId);
+      if (index > -1) {
+        targetIds.splice(index, 1); // 배열에서 내 소켓 ID 제거
+      }
+      // 방에 아무도 없으면 Map에서 삭제
+      if (targetIds.length === 0) {
+        userMap.delete(roomId);
+      }
+    }
+    console.log(`[해제] ${socketId} 가 방 ${roomId}에서 나감`);
+  });
+}

--- a/src/infra/websocket/websocket.ts
+++ b/src/infra/websocket/websocket.ts
@@ -1,0 +1,47 @@
+import { Server as HttpServer } from 'http';
+import { Server, Socket } from 'socket.io';
+import { setupChatEventHandlers } from './chat.js';
+
+// 싱글톤 웹소켓 서버 클래스
+export class WebSocketServer {
+  private static instance : WebSocketServer;
+  private io: Server | null = null;
+  public userMap: Map<string, string[]> = new Map();
+
+  private constructor() {
+    console.log('==웹소켓 서버 시작==');
+  }
+
+  public static getInstance(): WebSocketServer {
+    if (!WebSocketServer.instance) {
+      WebSocketServer.instance = new WebSocketServer();
+    }
+    return WebSocketServer.instance;
+  }
+  public init(httpServer: HttpServer): void {
+    this.io = new Server(httpServer, {
+      cors: { 
+        origin: '*' 
+      },
+      pingInterval: 25000,
+      pingTimeout: 5000
+    });
+
+    this.io.use((socket, next) => {
+      const token = socket.handshake.query.token; 
+
+      // 테스트용 토큰 검증
+      if (token === 'test-token') {
+        next();
+      } else {
+        const err = new Error('인증 실패: 유효하지 않은 토큰입니다.');
+        next(err);
+      }
+    });
+
+    this.io.on('connection', (socket: Socket) => {
+      console.log(`웹소켓 연결 성공: ${socket.id}`);
+      setupChatEventHandlers(this.io!, socket);
+    });
+  }
+}


### PR DESCRIPTION
## 제목
feat: 채팅테이블 스키마 반영, 웹소켓 기본 세팅, 웹소켓테스트(#6)
<!-- 예: feat: 로그인 기능 구현 (#1) -->

## 개요

- 웹소켓 기능개발 및 테스트
- 채팅 스키마 반영(일부 다른 테이블도 반영됨)

<!-- PR 목적과 변경 이유를 간단히 설명해주세요. -->

## 주요 변경 사항

- [ ] app.ts에 웹소켓 설정 추가
- [ ] infra/websocket 에 웹소켓 설정 클래스 추가
- [ ] 채팅 테이블 스카마에 반영

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #6
- Relates to #6

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [ ] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [ ] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [ ] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [ ] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그
<img width="742" height="590" alt="image" src="https://github.com/user-attachments/assets/3cfe14ed-9caa-438b-8e3c-4fce41c5fe8e" />

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
```
CREATE EXTENSION IF NOT EXISTS pgcrypto;
CREATE OR REPLACE FUNCTION uuid_generate_v7()
RETURNS uuid
AS $$
DECLARE
  v_time bigint;
  v_bytes bytea;
BEGIN
  -- 1. 현재 UNIX 타임스탬프(ms) 추출
  v_time := floor(extract(epoch from clock_timestamp()) * 1000);

  -- 2. 10바이트 무작위 데이터 생성 (pgcrypto 확장 사용)
  v_bytes := gen_random_bytes(10);

  -- 3. 타임스탬프 결합 및 비트 연산 (Version 7 / Variant 설정)
  -- 48비트 시간 + 무작위 80비트 결합 후 버전/변종 비트 주입
  v_bytes := decode(lpad(to_hex(v_time), 12, '0'), 'hex') || v_bytes;
  v_bytes := set_byte(v_bytes, 6, (get_byte(v_bytes, 6) & 15) | 112); -- Version 7
  v_bytes := set_byte(v_bytes, 8, (get_byte(v_bytes, 8) & 63) | 128); -- Variant

  -- 4. 반환
  RETURN encode(v_bytes, 'hex')::uuid;
END;
$$ LANGUAGE plpgsql VOLATILE;

``` 
채팅 로직을 구현하기 위해서는 메세지 순서등 비교 연산을 사용해야 하는 부분이있어 시간 값을 기반으로 하여 비교연산이 가능한 uuidv7를 만들어두고 채팅메세지 pk로 사용
