### PR TITLE
Feat : Profile 조회 API 구현

### DIFF
--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -19,3 +19,84 @@ export interface SaleDetailResponseDto extends SaleResponseDto {
   billNumber: string;
   option: string;
 }
+
+// --- 5 GET 응답 타입 (profile/{id}, feed, item, proposal, review) ---
+
+export interface ProfileInfoResponse {
+  profilePhoto: string | null;
+  nickname: string | null;
+  avgStar: number | null;
+  reviewCount: number | null;
+  totalSaleCount: number;
+  keywords: string[];
+  bio: string | null;
+}
+
+export interface FeedItem {
+  feedId: string;
+  images: string[];
+  isPinned: boolean;
+}
+
+export interface FeedListResponse {
+  feeds: FeedItem[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface MarketItem {
+  itemId: string;
+  photo: string | null;
+  isWished: boolean;
+  title: string | null;
+  price: number | null;
+  avgStar: number | null;
+  reviewCount: number | null;
+  sellerName: string | null;
+}
+
+export interface MarketListResponse {
+  items: MarketItem[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface ProposalItem {
+  proposalId: string;
+  photo: string | null;
+  isWished: boolean;
+  title: string | null;
+  price: number | null;
+  avgStar: number | null;
+  reviewCount: number | null;
+  sellerName: string | null;
+}
+
+export interface ProposalListResponse {
+  proposals: ProposalItem[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface ReviewItem {
+  reviewId: string;
+  userId: string | null;
+  userName: string | null;
+  userNickname: string | null;
+  userProfilePhoto: string | null;
+  star: number | null;
+  createdAt: Date | null;
+  content: string | null;
+  productId: string | null;
+  productType: 'ITEM' | 'PROPOSAL' | null;
+  productTitle: string | null;
+  productPhoto: string | null;
+  productPrice: number | null;
+  photos: string[];
+}
+
+export interface ReviewListResponse {
+  reviews: ReviewItem[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -12,6 +12,7 @@ import {
   Security,
   Request
 } from 'tsoa';
+import type { Request as ExpressRequest } from 'express';
 import { ProfileService } from './profile.service.js';
 import {
   ErrorResponse,
@@ -26,7 +27,12 @@ import {
 } from './dto/profile.req.dto.js';
 import {
   SaleDetailResponseDto,
-  SaleResponseDto
+  SaleResponseDto,
+  ProfileInfoResponse,
+  FeedListResponse,
+  MarketListResponse,
+  ProposalListResponse,
+  ReviewListResponse
 } from './dto/profile.res.dto.js';
 import { Request as ExRequest } from 'express';
 import { Item, Reform } from './profile.model.js';
@@ -151,5 +157,192 @@ export class ProfileController extends Controller {
     const data = await this.profileService.getSaleDetail(ownerId, id);
 
     return new ResponseHandler(data.toResponse());
+  }
+
+  /**
+   * 프로필 기본 정보 조회
+   * @summary owner ID로 프로필 정보(닉네임, 평점, 리뷰 수 등)를 조회합니다
+   * @param id owner UUID
+   * @returns 프로필 정보
+   */
+  @Get('{id}')
+  @SuccessResponse(200, '프로필 정보 조회 성공')
+  @Response<ErrorResponse>(
+    404,
+    '프로필을 찾을 수 없습니다.',
+    {
+      resultType: 'FAIL',
+      error: {
+        errorCode: 'OWNER-NOT-FOUND',
+        reason: '프로필을 찾을 수 없습니다.',
+        data: 'Owner ID: {id}'
+      },
+      success: null
+    }
+  )
+  @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  public async getProfileInfo(
+    @Path() id: string
+  ): Promise<TsoaResponse<ProfileInfoResponse>> {
+    const result = await this.profileService.getProfileInfo(id);
+    return new ResponseHandler(result);
+  }
+
+  /**
+   * 프로필 피드 목록 조회 (cursor 기반)
+   * @summary owner의 피드 목록을 조회합니다 (공개)
+   * @param id owner UUID
+   * @param cursor 페이지네이션 커서 (선택)
+   * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
+   * @returns 피드 목록
+   */
+  @Get('{id}/feed')
+  @SuccessResponse(200, '피드 목록 조회 성공')
+  @Response<ErrorResponse>(
+    404,
+    '프로필을 찾을 수 없습니다.',
+    {
+      resultType: 'FAIL',
+      error: {
+        errorCode: 'OWNER-NOT-FOUND',
+        reason: '프로필을 찾을 수 없습니다.',
+        data: 'Owner ID: {id}'
+      },
+      success: null
+    }
+  )
+  @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  public async getProfileFeed(
+    @Path() id: string,
+    @Query() cursor?: string,
+    @Query() limit?: number
+  ): Promise<TsoaResponse<FeedListResponse>> {
+    const limitValue = limit && limit > 0 ? limit : 20;
+    const result = await this.profileService.getProfileFeed(
+      id,
+      cursor,
+      limitValue
+    );
+    return new ResponseHandler(result);
+  }
+
+  /**
+   * 프로필 판매 상품 목록 조회 (cursor 기반)
+   * @summary owner의 판매 상품 목록을 조회합니다 (로그인 시 찜 여부 포함)
+   * @param id owner UUID
+   * @param cursor 페이지네이션 커서 (선택)
+   * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
+   * @returns 판매 상품 목록
+   */
+  @Get('{id}/item')
+  @SuccessResponse(200, '판매 상품 목록 조회 성공')
+  @Response<ErrorResponse>(
+    404,
+    '프로필을 찾을 수 없습니다.',
+    {
+      resultType: 'FAIL',
+      error: {
+        errorCode: 'OWNER-NOT-FOUND',
+        reason: '프로필을 찾을 수 없습니다.',
+        data: 'Owner ID: {id}'
+      },
+      success: null
+    }
+  )
+  @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  public async getProfileItems(
+    @Path() id: string,
+    @Request() req: ExpressRequest,
+    @Query() cursor?: string,
+    @Query() limit?: number
+  ): Promise<TsoaResponse<MarketListResponse>> {
+    const limitValue = limit && limit > 0 ? limit : 20;
+    const userId = req.user?.id;
+    const result = await this.profileService.getProfileItems(
+      id,
+      cursor,
+      limitValue,
+      userId
+    );
+    return new ResponseHandler(result);
+  }
+
+  /**
+   * 프로필 주문제작 목록 조회 (cursor 기반)
+   * @summary owner의 주문제작 상품 목록을 조회합니다 (로그인 시 찜 여부 포함)
+   * @param id owner UUID
+   * @param cursor 페이지네이션 커서 (선택)
+   * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
+   * @returns 주문제작 목록
+   */
+  @Get('{id}/proposal')
+  @SuccessResponse(200, '주문제작 목록 조회 성공')
+  @Response<ErrorResponse>(
+    404,
+    '프로필을 찾을 수 없습니다.',
+    {
+      resultType: 'FAIL',
+      error: {
+        errorCode: 'OWNER-NOT-FOUND',
+        reason: '프로필을 찾을 수 없습니다.',
+        data: 'Owner ID: {id}'
+      },
+      success: null
+    }
+  )
+  @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  public async getProfileProposals(
+    @Path() id: string,
+    @Request() req: ExpressRequest,
+    @Query() cursor?: string,
+    @Query() limit?: number
+  ): Promise<TsoaResponse<ProposalListResponse>> {
+    const limitValue = limit && limit > 0 ? limit : 20;
+    const userId = req.user?.id;
+    const result = await this.profileService.getProfileProposals(
+      id,
+      cursor,
+      limitValue,
+      userId
+    );
+    return new ResponseHandler(result);
+  }
+
+  /**
+   * 프로필 리뷰 목록 조회 (cursor 기반)
+   * @summary owner에 대한 리뷰 목록을 조회합니다 (공개)
+   * @param id owner UUID
+   * @param cursor 페이지네이션 커서 (선택)
+   * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
+   * @returns 리뷰 목록
+   */
+  @Get('{id}/review')
+  @SuccessResponse(200, '리뷰 목록 조회 성공')
+  @Response<ErrorResponse>(
+    404,
+    '프로필을 찾을 수 없습니다.',
+    {
+      resultType: 'FAIL',
+      error: {
+        errorCode: 'OWNER-NOT-FOUND',
+        reason: '프로필을 찾을 수 없습니다.',
+        data: 'Owner ID: {id}'
+      },
+      success: null
+    }
+  )
+  @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  public async getProfileReviews(
+    @Path() id: string,
+    @Query() cursor?: string,
+    @Query() limit?: number
+  ): Promise<TsoaResponse<ReviewListResponse>> {
+    const limitValue = limit && limit > 0 ? limit : 20;
+    const result = await this.profileService.getProfileReviews(
+      id,
+      cursor,
+      limitValue
+    );
+    return new ResponseHandler(result);
   }
 }

--- a/src/routes/profile/profile.error.ts
+++ b/src/routes/profile/profile.error.ts
@@ -29,3 +29,9 @@ export class OrderItemError extends BasicError {
     super(400, 'e400', '판매목록을 조회하는중 오류가 발생했습니다', des);
   }
 }
+
+export class OwnerNotFound extends BasicError {
+  constructor(ownerId: string) {
+    super(404, 'OWNER-NOT-FOUND', '프로필을 찾을 수 없습니다.', `Owner ID: ${ownerId}`);
+  }
+}

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -2,7 +2,8 @@ import { ProfileRepository } from './profile.repository.js';
 import {
   CategoryNotExist,
   ItemAddError,
-  OrderItemError
+  OrderItemError,
+  OwnerNotFound
 } from './profile.error.js';
 import { SaleRequestDto } from './dto/profile.req.dto.js';
 import {
@@ -13,7 +14,13 @@ import {
   Sale,
   SaleDetail
 } from './profile.model.js';
-
+import type {
+  ProfileInfoResponse,
+  FeedListResponse,
+  MarketListResponse,
+  ProposalListResponse,
+  ReviewListResponse
+} from './dto/profile.res.dto.js';
 export class ProfileService {
   private profileRepository: ProfileRepository;
 
@@ -50,9 +57,10 @@ export class ProfileService {
           await this.profileRepository.addReform(data as ReformDto, categoryId);
           break;
       }
-    } catch (err: any) {
-      console.log(err);
-      throw new Error(err);
+    } catch (err: unknown) {
+      if (err instanceof CategoryNotExist) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ItemAddError(message);
     }
   }
 
@@ -90,8 +98,9 @@ export class ProfileService {
         const title = titleMap.get(order.target_id ?? '') ?? '';
         return Sale.create(order, title);
       });
-    } catch (err: any) {
-      throw new OrderItemError(err);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new OrderItemError(message);
     }
   }
 
@@ -120,5 +129,317 @@ export class ProfileService {
     }
 
     return SaleDetail.create(order, option, title);
+  }
+
+  async getProfileInfo(id: string): Promise<ProfileInfoResponse> {
+    const owner = await this.profileRepository.findOwnerById(id);
+    if (!owner) {
+      throw new OwnerNotFound(id);
+    }
+
+    let avgStar = owner.avg_star ? Number(owner.avg_star) : null;
+    let reviewCount = owner.review_count;
+
+    if (avgStar === null || reviewCount === null) {
+      const stats = await this.profileRepository.findReviewStatsByOwnerId(id);
+      avgStar = stats._avg.star !== null ? Number(stats._avg.star) : null;
+      reviewCount = stats._count.review_id ?? 0;
+    }
+
+    const totalSaleCount = await this.profileRepository.countSaleByOwnerId(id);
+
+    return {
+      profilePhoto: owner.profile_photo,
+      nickname: owner.nickname,
+      avgStar,
+      reviewCount,
+      totalSaleCount,
+      keywords: owner.keywords ?? [],
+      bio: owner.bio
+    };
+  }
+
+  async getProfileFeed(
+    id: string,
+    cursor: string | undefined,
+    limit: number
+  ): Promise<FeedListResponse> {
+    const owner = await this.profileRepository.findOwnerById(id);
+    if (!owner) {
+      throw new OwnerNotFound(id);
+    }
+
+    const take = Math.min(limit, 50);
+    const feeds = await this.profileRepository.findFeedsByOwnerId(id, cursor, take);
+    const hasNext = feeds.length > take;
+    const actualFeeds = hasNext ? feeds.slice(0, take) : feeds;
+
+    const feedItems = actualFeeds.map(
+      (feed: {
+        feed_id: string;
+        feed_photo: Array<{ content: string | null }>;
+        is_pinned: boolean | null;
+      }) => ({
+        feedId: feed.feed_id,
+        images: feed.feed_photo
+          .map((p: { content: string | null }) => p.content ?? '')
+          .filter((url: string) => url !== ''),
+        isPinned: feed.is_pinned ?? false
+      })
+    );
+
+    const nextCursor =
+      hasNext && actualFeeds.length > 0 ? actualFeeds[actualFeeds.length - 1].feed_id : null;
+
+    return {
+      feeds: feedItems,
+      nextCursor,
+      hasNext
+    };
+  }
+
+  async getProfileItems(
+    id: string,
+    cursor: string | undefined,
+    limit: number,
+    userId: string | undefined
+  ): Promise<MarketListResponse> {
+    const owner = await this.profileRepository.findOwnerById(id);
+    if (!owner) {
+      throw new OwnerNotFound(id);
+    }
+
+    const take = Math.min(limit, 50);
+    const items = await this.profileRepository.findItemsByOwnerId(id, cursor, take);
+    const hasNext = items.length > take;
+    const actualItems = hasNext ? items.slice(0, take) : items;
+
+    let wishedItemIds: string[] = [];
+    if (userId && actualItems.length > 0) {
+      const itemIds = actualItems.map(
+        (i: { item_id: string }) => i.item_id
+      );
+      wishedItemIds = await this.profileRepository.findUserWishTargetIds(
+        userId,
+        'ITEM',
+        itemIds
+      );
+    }
+
+    const itemList = actualItems.map(
+      (item: {
+        item_id: string;
+        item_photo: Array<{ content: string | null }>;
+        title: string | null;
+        price: unknown;
+        avg_star: unknown;
+        review_count: number | null;
+      }) => ({
+      itemId: item.item_id,
+      photo: item.item_photo[0]?.content ?? null,
+      isWished: wishedItemIds.includes(item.item_id),
+      title: item.title,
+      price: item.price !== null ? Number(item.price) : null,
+      avgStar: item.avg_star !== null ? Number(item.avg_star) : null,
+      reviewCount: item.review_count,
+      sellerName: owner.nickname
+      })
+    );
+
+    const nextCursor =
+      hasNext && actualItems.length > 0 ? actualItems[actualItems.length - 1].item_id : null;
+
+    return {
+      items: itemList,
+      nextCursor,
+      hasNext
+    };
+  }
+
+  async getProfileProposals(
+    id: string,
+    cursor: string | undefined,
+    limit: number,
+    userId: string | undefined
+  ): Promise<ProposalListResponse> {
+    const owner = await this.profileRepository.findOwnerById(id);
+    if (!owner) {
+      throw new OwnerNotFound(id);
+    }
+
+    const take = Math.min(limit, 50);
+    const proposals = await this.profileRepository.findProposalsByOwnerId(
+      id,
+      cursor,
+      take
+    );
+    const hasNext = proposals.length > take;
+    const actualProposals = hasNext ? proposals.slice(0, take) : proposals;
+
+    let wishedProposalIds: string[] = [];
+    if (userId && actualProposals.length > 0) {
+      const proposalIds = actualProposals.map(
+        (p: { reform_proposal_id: string }) => p.reform_proposal_id
+      );
+      wishedProposalIds = await this.profileRepository.findUserWishTargetIds(
+        userId,
+        'PROPOSAL',
+        proposalIds
+      );
+    }
+
+    const proposalList = actualProposals.map(
+      (proposal: {
+        reform_proposal_id: string;
+        reform_proposal_photo: Array<{ content: string | null }>;
+        title: string | null;
+        price: unknown;
+        avg_star: unknown;
+        review_count: number | null;
+      }) => ({
+      proposalId: proposal.reform_proposal_id,
+      photo: proposal.reform_proposal_photo[0]?.content ?? null,
+      isWished: wishedProposalIds.includes(proposal.reform_proposal_id),
+      title: proposal.title,
+      price: proposal.price !== null ? Number(proposal.price) : null,
+      avgStar: proposal.avg_star !== null ? Number(proposal.avg_star) : null,
+      reviewCount: proposal.review_count,
+      sellerName: owner.nickname
+      })
+    );
+
+    const nextCursor =
+      hasNext && actualProposals.length > 0
+        ? actualProposals[actualProposals.length - 1].reform_proposal_id
+        : null;
+
+    return {
+      proposals: proposalList,
+      nextCursor,
+      hasNext
+    };
+  }
+
+  async getProfileReviews(
+    id: string,
+    cursor: string | undefined,
+    limit: number
+  ): Promise<ReviewListResponse> {
+    const owner = await this.profileRepository.findOwnerById(id);
+    if (!owner) {
+      throw new OwnerNotFound(id);
+    }
+
+    const take = Math.min(limit, 50);
+    const reviews = await this.profileRepository.findReviewsByOwnerId(id, cursor, take);
+    const hasNext = reviews.length > take;
+    const actualReviews = hasNext ? reviews.slice(0, take) : reviews;
+
+    type UserInfo = { user_id: string; name: string | null; nickname: string | null; profile_photo: string | null };
+    const userIds = actualReviews
+      .map((r: { user_id: string | null }) => r.user_id)
+      .filter((uid: string | null): uid is string => uid != null);
+    const users = await this.profileRepository.findUsersByIds(userIds);
+    const userMap = new Map<string, UserInfo>(users.map((u: UserInfo) => [u.user_id, u]));
+
+    const itemIds: string[] = actualReviews
+      .filter(
+        (r: { order: { target_type: string | null; target_id: string | null } | null }) =>
+          r.order?.target_type === 'ITEM' && r.order?.target_id
+      )
+      .map((r: { order: { target_id: string | null } | null }) => r.order!.target_id!);
+    const proposalIds: string[] = actualReviews
+      .filter(
+        (r: { order: { target_type: string | null; target_id: string | null } | null }) =>
+          r.order?.target_type === 'PROPOSAL' && r.order?.target_id
+      )
+      .map((r: { order: { target_id: string | null } | null }) => r.order!.target_id!);
+
+    const [itemInfos, proposalInfos] = await Promise.all([
+      this.profileRepository.getItemInfos([...new Set(itemIds)]),
+      this.profileRepository.getProposalInfos([...new Set(proposalIds)])
+    ]);
+    type ProductInfo = { title: string | null; price: number | null; photo: string | null };
+    const itemMap = new Map<string, ProductInfo>(
+      itemInfos.map((i: { item_id: string } & ProductInfo) => [i.item_id, { title: i.title, price: i.price, photo: i.photo }])
+    );
+    const proposalMap = new Map<string, ProductInfo>(
+      proposalInfos.map((p: { reform_proposal_id: string } & ProductInfo) => [
+        p.reform_proposal_id,
+        { title: p.title, price: p.price, photo: p.photo }
+      ])
+    );
+
+    const reviewList = actualReviews.map(
+      (review: {
+        review_id: string;
+        user_id: string | null;
+        order: { target_type: string | null; target_id: string | null } | null;
+        star: number | null;
+        created_at: Date | null;
+        content: string | null;
+        review_photo: Array<{ content: string | null }>;
+      }) => {
+        const order = review.order;
+        const user = review.user_id ? userMap.get(review.user_id) : null;
+        let productId: string | null = null;
+        let productType: 'ITEM' | 'PROPOSAL' | null = null;
+        let productTitle: string | null = null;
+        let productPhoto: string | null = null;
+        let productPrice: number | null = null;
+
+        if (order?.target_id && order?.target_type) {
+          productId = order.target_id;
+          productType =
+            order.target_type === 'ITEM'
+              ? 'ITEM'
+              : order.target_type === 'PROPOSAL'
+                ? 'PROPOSAL'
+                : null;
+
+          if (productType === 'ITEM' && productId) {
+            const item = itemMap.get(productId);
+            productTitle = item?.title ?? null;
+            productPhoto = item?.photo ?? null;
+            productPrice = item?.price ?? null;
+          } else if (productType === 'PROPOSAL' && productId) {
+            const proposal = proposalMap.get(productId);
+            productTitle = proposal?.title ?? null;
+            productPhoto = proposal?.photo ?? null;
+            productPrice = proposal?.price ?? null;
+          }
+        }
+
+        return {
+          reviewId: review.review_id,
+          userId: user?.user_id ?? review.user_id ?? null,
+          userName: user?.name ?? null,
+          userNickname: user?.nickname ?? null,
+          userProfilePhoto: user?.profile_photo ?? null,
+          star: review.star,
+          createdAt: review.created_at,
+          content: review.content,
+          productId,
+          productType,
+          productTitle,
+          productPhoto,
+          productPrice,
+          photos: review.review_photo
+            .map((p: { content: string | null }) => p.content ?? '')
+            .filter((url: string) => url !== '')
+        };
+      }
+    );
+
+    const nextCursor =
+      hasNext && actualReviews.length > 0
+        ? actualReviews[actualReviews.length - 1].review_id
+        : null;
+
+    return {
+      reviews: reviewList,
+      nextCursor,
+      hasNext
+    };
   }
 }


### PR DESCRIPTION
## 제목

Feat : Profile 조회 API 구현

## 개요

5개의 프로필 관련 조회를 구현하였습니다.

## 주요 변경 사항

- [x] 프로필 기본 정보 조회 API 추가 (GET /profile/{id})
- [x] 프로필 피드 목록 조회 API 추가 (GET /profile/{id}/feed)
- [x] 프로필 판매 상품 목록 조회 API 추가 (GET /profile/{id}/item)
- [x] 프로필 주문제작 목록 조회 API 추가 (GET /profile/{id}/proposal)
- [x] 프로필 리뷰 목록 조회 API 추가 (GET /profile/{id}/review)
- [x] 관련 DTO, 서비스, 리포지토리 메소드 및 에러 처리 구현


## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #12
- Relates to #12 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
