### PR TITLE
Refactor : 견적서 생성 로직 리팩터링

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -220,6 +220,7 @@ model order {
   user_id          String             @db.Uuid
   receipt_id       String             @db.Uuid
   quantity         Int?               @default(1)
+  tracking_number  String?            @db.VarChar(50)
   owner            owner              @relation(fields: [owner_id], references: [owner_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_owner_TO_order_1")
   user             user               @relation(fields: [user_id], references: [user_id], onDelete: NoAction, onUpdate: NoAction, map: "FK_user_TO_order_1")
   receipt          receipt            @relation(fields: [receipt_id], references: [receipt_id], onDelete: Cascade, onUpdate: NoAction, map: "fk_receipt_to_order_1")
@@ -441,7 +442,7 @@ model cart_option {
 }
 
 model quote_photo {
-  quote_photo_id String    @id(map: "quote_photo_pk") @db.Uuid
+  quote_photo_id String    @id(map: "quote_photo_pk") @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   content        String?   @db.VarChar(100)
   created_at     DateTime? @db.Date
   photo_order    Int?

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -1,4 +1,3 @@
-import { order_status_enum } from '@prisma/client';
 import { UUID } from '../../../@types/common.js';
 
 /** 프로필 피드 등록 성공 응답 DTO */
@@ -9,7 +8,7 @@ export interface AddFeedResponseDto {
 export interface SaleResponseDto {
   orderId: UUID;
   targetId: UUID;
-  status: order_status_enum;
+  status: string;
   price: number;
   deliveryFee: number;
   userName: string;

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, order_status_enum } from '@prisma/client';
 import { UUID } from '../../@types/common.js';
 import {
   SaleDetailResponseDto,
@@ -9,6 +9,18 @@ import {
   AddReformRequestDto
 } from './dto/profile.req.dto.js';
 import { Category, OptionGroup } from '../../@types/item.js';
+
+const ORDER_STATUS_LABELS: Record<order_status_enum, string> = {
+  PENDING: '결제 대기',
+  PAID: '결제 완료',
+  SENT: '발송 완료',
+  WORKING: '작업 중',
+  DELIVERY: '배송 중',
+  COMPLETE: '거래 완료',
+  SETTLEMENT: '정산 완료',
+  CANCELLED: '취소됨',
+  REFUNDED: '환불됨'
+};
 
 export type RawSaleData = Prisma.orderGetPayload<{
   select: {
@@ -120,7 +132,7 @@ export class Sale {
     return new Sale({
       orderId: raw.order_id as UUID,
       targetId: raw.target_id as UUID,
-      status: raw.status!,
+      status: ORDER_STATUS_LABELS[raw.status!],
       price: raw.price!.toNumber(),
       deliveryFee: raw.delivery_fee!.toNumber(),
       userName: raw.user.name ?? '',
@@ -155,7 +167,7 @@ export class SaleDetail {
     return new SaleDetail({
       orderId: raw.order_id as UUID,
       targetId: raw.target_id as UUID,
-      status: raw.status!,
+      status: ORDER_STATUS_LABELS[raw.status!],
       price: raw.price!.toNumber(),
       deliveryFee: raw.delivery_fee!.toNumber(),
       userName: raw.user.name ?? '',

--- a/src/routes/reform/dto/reform.req.dto.ts
+++ b/src/routes/reform/dto/reform.req.dto.ts
@@ -2,12 +2,22 @@ import { Category } from '../../../@types/item.js';
 import { ImageUrls } from '../../common/upload.dto.js';
 
 export interface AddQuoteReq {
-  userId: string;
+  images: string[];
+  ownerId: string;
   reform_request_id: string;
   price: number;
   delivery: number;
   content: string;
   expected_working: number;
+}
+
+export interface ReformQuoteRequest {
+  images: string[];
+  targetId: string;
+  price: number;
+  contents: string;
+  delivery: number;
+  expectedWorking: number;
 }
 
 export interface ReformRequestRequest {

--- a/src/routes/reform/reform.controller.ts
+++ b/src/routes/reform/reform.controller.ts
@@ -27,7 +27,8 @@ import {
   ModifyProposalRequest,
   ModifyRequestRequest,
   ReformRequestRequest,
-  ReformFilter
+  ReformFilter,
+  ReformQuoteRequest
 } from './dto/reform.req.dto.js';
 import {
   ReformDetailProposalResponseDto,
@@ -257,21 +258,25 @@ export class ReformController extends Controller {
     return new ResponseHandler(ans);
   }
 
-  // /**
-  //  * @summary 요청서를 바탕으로 새로운 견적서를 생성합니다.
-  //  * @param body JSON stringify된 객체 {"userId":"80f80aec-a750-4159-8e17-398a9dc6f14c","reform_request_id":"03719d41-d021-4171-bdac-f26b511bb423","price":10000,"delivery":1000,"content":"상세 제안 내용 텍스트 샘플입니다","expected_working":5}
-  //  * @param images 견적에 첨부할 이미지 파일 배열
-  //  * @returns 생성된 견적 정보
-  //  */
-  // @Post('/quote')
-  // @SuccessResponse(200, '생성 성공')
-  // public async addQuote(
-  //   @FormField() body: string,
-  //   @UploadedFiles() images: Express.Multer.File[]
-  // ) {
-  //   const ownerId = 'a209454d-5e95-4ffb-ba6f-beeabef34b50'; // ownerId는 reformer만 보내니까 JWT로 인증하도록
-  //   const dto = JSON.parse(body) as AddQuoteReq;
-  //   const orderDto = new OrderQuoteDto(dto, ownerId);
-  //   await this.reformService.addQuoteOrder(orderDto, images);
-  // }
+  /**
+   * @summary 요청서를 바탕으로 새로운 견적서를 생성합니다.
+   * @param body 견적서
+   * @returns 생성된 견적서 UUID
+   */
+  @Post('/quote')
+  @Security('jwt')
+  @SuccessResponse(200, '생성 성공')
+  public async addQuote(
+    @Request() req: ExRequest,
+    @Body() body: ReformQuoteRequest
+  ): Promise<TsoaResponse<{ order_id: string }>> {
+    const payload = req.user;
+    if (payload.role !== 'reformer')
+      throw new ReformError('리폼러만 견적서를 작성 할 수 있습니다');
+
+    const ownerId = req.user.id;
+
+    const ans = await this.reformService.addReformQuote(body, ownerId);
+    return new ResponseHandler(ans);
+  }
 }

--- a/src/routes/reform/reform.model.ts
+++ b/src/routes/reform/reform.model.ts
@@ -9,6 +9,7 @@ import {
   ModifyProposalRequest,
   ModifyRequestRequest,
   ReformProposalRequest,
+  ReformQuoteRequest,
   ReformRequestRequest
 } from './dto/reform.req.dto.js';
 import { Category } from '../../@types/item.js';
@@ -57,6 +58,17 @@ export interface ReformProposalUpdateData {
   expectedWorking?: number;
   category?: Category;
   title?: string;
+}
+
+export interface ReformQutoteCreateData {
+  ownerId: string;
+  userId: string;
+  target_id: string;
+  images: string[];
+  contents: string;
+  price: number;
+  delivery: number;
+  expectedWorking: number;
 }
 
 export type RawRequestLatest = Prisma.reform_requestGetPayload<{
@@ -378,6 +390,37 @@ export class ReformProposalFactory {
       expectedWorking: req.expectedWorking,
       category: req.category,
       title: req.title
+    });
+  }
+}
+
+export class ReformQuote {
+  private readonly props: ReformQutoteCreateData;
+
+  constructor(props: ReformQutoteCreateData) {
+    this.props = props;
+  }
+
+  toDto(): ReformQutoteCreateData {
+    return { ...this.props };
+  }
+}
+
+export class ReformQuoteFactory {
+  static create(
+    raw: ReformQuoteRequest,
+    userId: string,
+    ownerId: string
+  ): ReformQuote {
+    return new ReformQuote({
+      ownerId: ownerId,
+      userId: userId,
+      target_id: raw.targetId,
+      images: raw.images,
+      contents: raw.contents,
+      price: raw.price,
+      delivery: raw.delivery,
+      expectedWorking: raw.expectedWorking
     });
   }
 }

--- a/src/routes/reform/reform.repository.ts
+++ b/src/routes/reform/reform.repository.ts
@@ -9,6 +9,7 @@ import {
   RawRequestDetailImages,
   RawRequestLatest,
   ReformProposalUpdate,
+  ReformQuote,
   ReformRequestCreate,
   ReformRequestUpdate
 } from './reform.model.js';
@@ -465,19 +466,43 @@ export class ReformRepository {
     return result;
   }
 
-  // async addQuoteOrder(dto: OrderQuoteDto) {
-  //   await this.prisma.order.create({
-  //     data: {
-  //       status: dto.status,
-  //       target_type: dto.type,
-  //       target_id: dto.targetId,
-  //       price: dto.price,
-  //       delivery_fee: dto.delivery,
-  //       amount: dto.amount,
-  //       content: dto.content,
-  //       owner_id: dto.ownerId,
-  //       user_id: dto.userId
-  //     }
-  //   });
-  // }
+  async selectReformRequestUser(
+    id: string
+  ): Promise<{ user_id: string } | null> {
+    return await prisma.reform_request.findFirst({
+      where: { reform_request_id: id },
+      select: { user_id: true }
+    });
+  }
+  async insertReformQuotePhoto(dto: ReformQuote, order_id: string) {
+    const { images, ...data } = dto.toDto();
+    return await prisma.quote_photo.createMany({
+      data: images.map((img, index) => ({
+        order_id: order_id,
+        content: img,
+        photo_order: index + 1
+      }))
+    });
+  }
+
+  async insertReformQuote(dto: ReformQuote) {
+    const body = dto.toDto();
+    return await prisma.order.create({
+      data: {
+        owner_id: body.ownerId,
+        user_id: body.userId,
+        content: body.contents,
+        price: body.price,
+        target_type: 'REQUEST',
+        target_id: body.target_id,
+        delivery_fee: body.delivery,
+        //FIXME: 하드코딩 제거
+        receipt_id: '3a002aa5-f93e-487e-b253-ad47bae7b3e4',
+        status: 'PENDING'
+      },
+      select: {
+        order_id: true
+      }
+    });
+  }
 }

--- a/src/routes/reform/reform.service.ts
+++ b/src/routes/reform/reform.service.ts
@@ -1,5 +1,5 @@
 import { S3 } from '../../config/s3.js';
-import { ReformFilter } from './dto/reform.req.dto.js';
+import { ReformFilter, ReformQuoteRequest } from './dto/reform.req.dto.js';
 import {
   ReformHomeResponse,
   ReformProposalResponseDto,
@@ -13,11 +13,14 @@ import {
   ReformDetailRequestResponse,
   ReformDetailProposalResponse,
   ReformRequestUpdate,
-  ReformProposalUpdate
+  ReformProposalUpdate,
+  ReformQuoteFactory
 } from './reform.model.js';
 import { ReformRepository } from './reform.repository.js';
 import { addSearchSyncJob } from '../../worker/search.queue.js';
 import { CustomJwt } from '../../@types/expreees.js';
+import { runInThisContext } from 'vm';
+import { runInTransaction } from '../../config/prisma.config.js';
 
 export class ReformService {
   private reformRepository: ReformRepository;
@@ -320,25 +323,51 @@ export class ReformService {
     }
   }
 
-  // async addQuoteOrder(dto: OrderQuoteDto, images: Express.Multer.File[]) {
-  //   try {
-  //     const image: {
-  //       content: string;
-  //       photo_order: number;
-  //     }[] = [];
-  //     for (let i = 0; i < images.length; i++) {
-  //       const ans = await this.s3.uploadToS3(images[i]);
-  //       const obj = {
-  //         content: ans,
-  //         photo_order: i + 1
-  //       };
-  //       image.push(obj);
-  //     }
+  async addReformQuote(data: ReformQuoteRequest, ownerId: string) {
+    try {
+      return await runInTransaction(async () => {
+        const check = await this.reformRepository.selectReformRequestUser(
+          data.targetId
+        );
 
-  //     dto.images = image;
-  //     await this.refromModel.addQuoteOrder(dto);
-  //   } catch (err: any) {
-  //     throw new ReformError(err);
-  //   }
-  // }
+        if (check === null)
+          throw new ReformError('요청서가 존재하지 않습니다.');
+
+        if (data.contents !== undefined && data.contents.length > 1000)
+          throw new ReformError('내용은 1000자를 넘길 수 없습니다');
+
+        if (data.images !== undefined && data.images.length > 10)
+          throw new ReformError('이미지는 최대 10장 까지 첨부 가능합니다');
+
+        if (
+          data.price !== undefined &&
+          (data.price < 0 || data.price > 999999999)
+        )
+          throw new ReformError('가격은 0원~999999999원 까지입니다.');
+
+        if (
+          data.delivery !== undefined &&
+          (data.delivery < 0 || data.delivery > 999999999)
+        )
+          throw new ReformError('배송비는 0원~999999999원 까지입니다.');
+
+        if (
+          data.expectedWorking !== undefined &&
+          (data.expectedWorking < 0 || data.expectedWorking > 365)
+        )
+          throw new ReformError('예상 작업일은 0일~365일 까지입니다.');
+
+        const userId = check.user_id;
+        const dto = ReformQuoteFactory.create(data, userId, ownerId);
+        const ans = await this.reformRepository.insertReformQuote(dto);
+
+        if (ans === null) throw new ReformError('생성중 오류가 발생했습니다.');
+        await this.reformRepository.insertReformQuotePhoto(dto, ans.order_id);
+
+        return ans;
+      });
+    } catch (err: any) {
+      throw new ReformError(err);
+    }
+  }
 }


### PR DESCRIPTION
## 제목

<!-- 예: feat: 로그인 기능 구현 (#1) -->

## 개요

<!-- PR 목적과 변경 이유를 간단히 설명해주세요. -->
견적서 생성로직을 리팩터링했습니다.
프로필 - 판매관리에서 주문상태를 자연어로 매핑하는 로직을 추가했습니다.

## 주요 변경 사항

- [ ]
- [ ]

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #
- Relates to #

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [ ] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [ ] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [ ] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [ ] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
