### PR TITLE
Feat : 비 로그인 필요 API 토큰 미 처리 구현

### DIFF
--- a/src/routes/home/home.controller.ts
+++ b/src/routes/home/home.controller.ts
@@ -211,7 +211,7 @@ export class HomeController extends Controller {
     }
   )
   @Response<ErrorResponse>(500, '서버 오류', commonError.serverError)
-  @Security('jwt', [])
+  @Security('jwt_optional')
   @Get('/')
   public async getHome(
     @Request() req: ExpressRequest

--- a/src/routes/market/market.controller.ts
+++ b/src/routes/market/market.controller.ts
@@ -84,7 +84,7 @@ export class MarketController extends Controller {
     }
   )
   @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
-  @Security('jwt', [])
+  @Security('jwt_optional')
   @Example<TsoaResponse<GetItemListResponseDto>>({
     resultType: 'SUCCESS',
     error: null,
@@ -171,7 +171,7 @@ export class MarketController extends Controller {
     }
   )
   @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
-  @Security('jwt', [])
+  @Security('jwt_optional')
   @Example<TsoaResponse<GetItemDetailResponseDto>>({
     resultType: 'SUCCESS',
     error: null,

--- a/src/routes/search/search.controller.ts
+++ b/src/routes/search/search.controller.ts
@@ -33,7 +33,7 @@ export class SearchController extends Controller {
    */
   @Get('/')
   @SuccessResponse(200, '검색 완료')
-  @Security('jwt', ['user', 'reformer'])
+  @Security('jwt_optional')
   @Example({
     type: 'REQUEST',
     query: '유니폼'
@@ -44,9 +44,9 @@ export class SearchController extends Controller {
     @Query() cursor?: string,
     @Request() req?: ExRequest
   ): Promise<TsoaResponse<SearchListResDTO>> {
-    const payload = req!.user;
-    const userId = payload.id;
-    const role = payload.role;
+    const payload = req?.user;
+    const userId = payload?.id;
+    const role = payload?.role;
 
     const result = await this.searchService.search(
       type,

--- a/src/routes/search/search.service.ts
+++ b/src/routes/search/search.service.ts
@@ -13,8 +13,8 @@ export class SearchService {
   public async search(
     type: target_type_enum,
     query: string,
-    userId: string,
-    role: Role,
+    userId?: string,
+    role?: Role,
     cursor?: string
   ): Promise<SearchListResDTO> {
     const searchAfter = CursorUtil.decode<SearchCursor>(cursor);
@@ -85,15 +85,15 @@ export class SearchService {
   }
 
   private async getIsLikedSet(
-    userId: string,
+    userId: string | undefined,
     type: target_type_enum,
     resultIds: string[],
-    role: Role
+    role: Role | undefined
   ): Promise<Set<string>> {
     const isLikedSet = new Set<string>();
     if (!userId || resultIds.length === 0) return isLikedSet;
 
-    if (role === 'user') {
+    if (role === 'user' && userId) {
       const wishes = await prisma.user_wish.findMany({
         where: {
           user_id: userId,


### PR DESCRIPTION
## 제목

<!-- 예: feat: 로그인 기능 구현 (#1) -->
Feat : 비 로그인 필요 API 토큰 미 처리 구현

## 개요

<!-- PR 목적과 변경 이유를 간단히 설명해주세요. -->
로그인시 찜 여부 등을 따로 반환해줘야하는 API에 로그인 없이 접근 가능하게 구현

## 주요 변경 사항

- [x] 아래 API 토큰 미 처리 구현(비 로그인  시 사용 가능)
GET	/home 메인
GET	/market 상품 목록
GET	/market/:itemId 상품 상세
GET	/reform/request/:id 리폼 요청서 상세
GET	/reform/proposal/:id 리폼 제안서 상세
GET /search 상품/요청/제안 검색

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #99 
- Relates to #99 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
