### PR TITLE
Feat : 리폼 요청글 및 구매 이력 관리 기능 구현

### DIFF
--- a/src/routes/profile/dto/profile.req.dto.ts
+++ b/src/routes/profile/dto/profile.req.dto.ts
@@ -112,3 +112,27 @@ export class AddFeedRequestDto {
 //     this.category = body.category;
 //   }
 // }
+
+export class OrderRequestDto {
+  type: 'ITEM' | 'REFORM' | 'ALL';
+  cursor: string;
+  limit: number;
+  userId: UUID;
+  onlyReviewAvailable: boolean;
+  order: 'asc' | 'desc';
+  constructor(
+    type: 'ITEM' | 'REFORM' | 'ALL',
+    cursor: string | undefined,
+    limit: number,
+    userId: UUID,
+    onlyReviewAvailable: boolean,
+    order: 'asc' | 'desc' = 'desc'
+  ) {
+    this.userId = userId;
+    this.type = type;
+    this.cursor = cursor ?? '';
+    this.limit = limit;
+    this.onlyReviewAvailable = onlyReviewAvailable;
+    this.order = order;
+  }
+}

--- a/src/routes/profile/dto/profile.req.dto.ts
+++ b/src/routes/profile/dto/profile.req.dto.ts
@@ -136,3 +136,21 @@ export class OrderRequestDto {
     this.order = order;
   }
 }
+
+export class RequestListRequestDto{
+  cursor: string;
+  limit: number;
+  userId: UUID;
+  order: 'asc' | 'desc' = 'desc';
+  constructor(
+    cursor: string | undefined,
+    limit: number,
+    userId: UUID,
+    order: 'asc' | 'desc' = 'desc'
+  ) {
+    this.cursor = cursor ?? '';
+    this.limit = limit;
+    this.userId = userId;
+    this.order = order;
+  }
+}

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -1,5 +1,6 @@
 import { order_status_enum } from '@prisma/client';
 import { UUID } from '../../../@types/common.js';
+import { RawOptionItemsWithGroup } from '../profile.model.js'
 
 /** 프로필 피드 등록 성공 응답 DTO */
 export interface AddFeedResponseDto {
@@ -136,4 +137,26 @@ export interface OrderResponseDto {
   deliveryPhone: string;
   deliveryPostalCode: string;
   deliveryRecipientName: string;
+}
+
+export interface OrderDetailResponseDto{
+  title: string;
+  thumbnail: string;
+  receiptNumber: string;
+  orderId: UUID;
+  targetType: string;
+  targetId: string;
+  status: order_status_enum;
+  price: number;
+  deliveryFee: number;
+  totalPrice: string;
+  trackingNumber: string;
+  createdAt: Date;
+  deliveryPostalCode: string;
+  deliveryAddress: string;
+  deliveryAddressDetail: string;
+  deliveryRecipientName: string;
+  deliveryPhone: string;
+  deliveryAddressName: string;
+  options: RawOptionItemsWithGroup[]
 }

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -1,6 +1,6 @@
 import { order_status_enum } from '@prisma/client';
 import { UUID } from '../../../@types/common.js';
-import { RawOptionItemsWithGroup } from '../profile.model.js'
+import { RawOptionItemsWithGroup, RequestData } from '../profile.model.js'
 
 /** 프로필 피드 등록 성공 응답 DTO */
 export interface AddFeedResponseDto {
@@ -158,4 +158,10 @@ export interface OrderDetailResponseDto{
   deliveryPhone: string;
   deliveryAddressName: string;
   options: RawOptionItemsWithGroup[]
+}
+
+export interface RequestsListResponseDto {
+  requestData: RequestData[], 
+  nextCursor: string | null, 
+  hasNext: boolean
 }

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -130,13 +130,12 @@ export interface OrderResponseDto {
   thumbnail: string;
   reviewAvailable: boolean;
   reviewId: UUID | null;
-  trackingNumber: string;
-  deliveryAddress: string;
-  deliveryAddressDetail: string;
-  deliveryAddressName: string;
-  deliveryPhone: string;
-  deliveryPostalCode: string;
-  deliveryRecipientName: string;
+}
+
+export interface OrderListResponseDto {
+  orders: OrderResponseDto[];
+  nextCursor: string | null;
+  hasNext: boolean;
 }
 
 export interface OrderDetailResponseDto{

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -1,3 +1,4 @@
+import { order_status_enum } from '@prisma/client';
 import { UUID } from '../../../@types/common.js';
 
 /** 프로필 피드 등록 성공 응답 DTO */
@@ -110,4 +111,29 @@ export interface ReviewListResponse {
   reviews: ReviewItem[];
   nextCursor: string | null;
   hasNext: boolean;
+}
+
+export interface OrderResponseDto {
+  receiptNumber: string;
+  orderId: UUID;
+  title: string;
+  targetId: UUID;
+  status: order_status_enum;
+  price: number;
+  deliveryFee: number;
+  totalPrice: string;
+  targetType: string;
+  quantity: number;
+  ownerNickname: string;
+  createdAt: Date;
+  thumbnail: string;
+  reviewAvailable: boolean;
+  reviewId: UUID | null;
+  trackingNumber: string;
+  deliveryAddress: string;
+  deliveryAddressDetail: string;
+  deliveryAddressName: string;
+  deliveryPhone: string;
+  deliveryPostalCode: string;
+  deliveryRecipientName: string;
 }

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -25,7 +25,8 @@ import {
   AddItemRequestDto,
   AddReformRequestDto,
   SaleRequestDto,
-  OrderRequestDto
+  OrderRequestDto,
+  RequestListRequestDto
 } from './dto/profile.req.dto.js';
 import {
   AddFeedResponseDto,
@@ -36,9 +37,9 @@ import {
   MarketListResponse,
   ProposalListResponse,
   ReviewListResponse,
-  OrderResponseDto,
   OrderDetailResponseDto,
-  OrderListResponseDto
+  OrderListResponseDto,
+  RequestsListResponseDto
 } from './dto/profile.res.dto.js';
 import { Request as ExRequest } from 'express';
 import { Item, Reform } from './profile.model.js';
@@ -310,8 +311,8 @@ export class ProfileController extends Controller {
    * @summary 사용자의 전체 구매이력 목록을 조회합니다
    * @returns 구매이력 목록
    * @param type 주문제작 or 판매상품 선택
-   * @param page 현재 페이지
-   * @param limit 한 페이지 보여줄 목록 수
+   * @param cursor 페이지네이션 커서
+   * @param limit 한 번에 보여줄 목록 수
    * @param OnlyReviewAvailable 리뷰 가능한 주문 목록만 조회하기 (리뷰 가능 조건 : PENDING이 아닐 때, 작성된 리뷰가 없을 때)
    */
   @Security('jwt', ['user'])
@@ -321,7 +322,6 @@ export class ProfileController extends Controller {
   public async getOrders(
     @Query() type: 'ITEM' | 'REFORM' | 'ALL',
     @Request() req: ExRequest,
-    // @Query() userId: string,
     @Query() cursor?: string,
     @Query() limit: number = 20,
     @Query() order: 'asc' | 'desc' = 'desc',
@@ -359,6 +359,30 @@ export class ProfileController extends Controller {
     const payload = req.user;
     const userId = payload.id;
     const data = await this.profileService.getOrderDetail(userId, id);
+    return new ResponseHandler(data);
+  }
+
+  /**
+   * 일반 유저 작성한 요청 글목록 조회
+   * @summary 작성한 요청글 목록을 조회합니다. (일반 유저, 자신의 글만 조회 가능)
+   * @param cursor 페이지네이션 커서 (optional)
+   * @param limit 한 번에 보여줄 목록 수 (기본 값 20)
+   * @return 사용자가 작성한 요청글 목록
+   */
+  @Get('requests')
+  @Security('jwt', ['user'])
+  @SuccessResponse(200, '작성 요청글 조회 성공')
+  @Response<ErrorResponse>(500, '서버에러', commonError.serverError)
+  public async getRequests(
+    @Request() req: ExRequest,
+    @Query() cursor?: string,
+    @Query() limit: number = 20,
+    @Query() order: 'asc' | 'desc' = 'desc',
+  ): Promise<TsoaResponse<RequestsListResponseDto>> {
+    const payload = req.user;
+    const userId = payload.id;
+    const dto = new RequestListRequestDto(cursor, limit, userId, order)
+    const data = await this.profileService.getRequests(dto);
     return new ResponseHandler(data);
   }
 

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -36,7 +36,8 @@ import {
   MarketListResponse,
   ProposalListResponse,
   ReviewListResponse,
-  OrderResponseDto
+  OrderResponseDto,
+  OrderDetailResponseDto
 } from './dto/profile.res.dto.js';
 import { Request as ExRequest } from 'express';
 import { Item, Reform } from './profile.model.js';
@@ -333,6 +334,27 @@ export class ProfileController extends Controller {
       return order.toResponse();
     });
     return new ResponseHandler(res);
+  }
+
+  
+  /**
+   * 구매 목록 상세 조회
+   * @summary 구매 목록 ID로 해당 목록의 상세 정보를 조회합니다
+   * @param id 구매 목록 ID (order_id)
+   * @returns 구매 목록 상세 정보
+   */
+  @Get('orders/:id')
+  @Security('jwt', ['user'])
+  @SuccessResponse(200, '구매 목록 상세 조회 성공')
+  @Response<ErrorResponse>(500, '서버에러', commonError.serverError)
+  public async getOrderDetail(
+    @Path() id: string,
+    @Request() req: ExRequest
+  ): Promise<TsoaResponse<OrderDetailResponseDto>> {
+    const payload = req.user;
+    const userId = payload.id;
+    const data = await this.profileService.getOrderDetail(userId, id);
+    return new ResponseHandler(data);
   }
 
   /**

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -24,7 +24,8 @@ import {
   AddFeedRequestDto,
   AddItemRequestDto,
   AddReformRequestDto,
-  SaleRequestDto
+  SaleRequestDto,
+  OrderRequestDto
 } from './dto/profile.req.dto.js';
 import {
   AddFeedResponseDto,
@@ -34,7 +35,8 @@ import {
   FeedListResponse,
   MarketListResponse,
   ProposalListResponse,
-  ReviewListResponse
+  ReviewListResponse,
+  OrderResponseDto
 } from './dto/profile.res.dto.js';
 import { Request as ExRequest } from 'express';
 import { Item, Reform } from './profile.model.js';
@@ -299,6 +301,38 @@ export class ProfileController extends Controller {
     const ownerId = payload.id;
     const result = await this.profileService.getProfileInfo(ownerId);
     return new ResponseHandler(result);
+  }
+
+  /**
+   * 구매 목록 조회
+   * @summary 사용자의 전체 구매이력 목록을 조회합니다
+   * @returns 구매이력 목록
+   * @param type 주문제작 or 판매상품 선택
+   * @param page 현재 페이지
+   * @param limit 한 페이지 보여줄 목록 수
+   * @param OnlyReviewAvailable 리뷰 가능한 주문 목록만 조회하기 (리뷰 가능 조건 : PENDING이 아닐 때)
+   */
+  @Get('orders')
+  // @Security('jwt', ['user'])
+  @SuccessResponse(200, '구매이력 조회 성공')
+  @Response<ErrorResponse>(500, '서버에러', commonError.serverError)
+  public async getOrders(
+    @Query() type: 'ITEM' | 'REFORM' | 'ALL',
+    @Query() userId: string,
+    @Query() cursor?: string,
+    @Query() limit: number = 20,
+    @Query() order: 'asc' | 'desc' = 'desc',
+    @Query() OnlyReviewAvailable: boolean = false,
+    // @Request() req: ExRequest,
+  ): Promise<TsoaResponse<OrderResponseDto[]>> {
+    // const payload = req.user;
+    // const userId = payload.id;
+    const dto = new OrderRequestDto(type, cursor, limit, userId, OnlyReviewAvailable, order);
+    const data = await this.profileService.getOrders(dto);
+    const res = data.map((order) => {
+      return order.toResponse();
+    });
+    return new ResponseHandler(res);
   }
 
   /**

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -37,7 +37,8 @@ import {
   ProposalListResponse,
   ReviewListResponse,
   OrderResponseDto,
-  OrderDetailResponseDto
+  OrderDetailResponseDto,
+  OrderListResponseDto
 } from './dto/profile.res.dto.js';
 import { Request as ExRequest } from 'express';
 import { Item, Reform } from './profile.model.js';
@@ -311,28 +312,32 @@ export class ProfileController extends Controller {
    * @param type 주문제작 or 판매상품 선택
    * @param page 현재 페이지
    * @param limit 한 페이지 보여줄 목록 수
-   * @param OnlyReviewAvailable 리뷰 가능한 주문 목록만 조회하기 (리뷰 가능 조건 : PENDING이 아닐 때)
+   * @param OnlyReviewAvailable 리뷰 가능한 주문 목록만 조회하기 (리뷰 가능 조건 : PENDING이 아닐 때, 작성된 리뷰가 없을 때)
    */
+  @Security('jwt', ['user'])
   @Get('orders')
-  // @Security('jwt', ['user'])
   @SuccessResponse(200, '구매이력 조회 성공')
   @Response<ErrorResponse>(500, '서버에러', commonError.serverError)
   public async getOrders(
     @Query() type: 'ITEM' | 'REFORM' | 'ALL',
-    @Query() userId: string,
+    @Request() req: ExRequest,
+    // @Query() userId: string,
     @Query() cursor?: string,
     @Query() limit: number = 20,
     @Query() order: 'asc' | 'desc' = 'desc',
     @Query() OnlyReviewAvailable: boolean = false,
-    // @Request() req: ExRequest,
-  ): Promise<TsoaResponse<OrderResponseDto[]>> {
-    // const payload = req.user;
-    // const userId = payload.id;
-    const dto = new OrderRequestDto(type, cursor, limit, userId, OnlyReviewAvailable, order);
-    const data = await this.profileService.getOrders(dto);
-    const res = data.map((order) => {
-      return order.toResponse();
-    });
+  ): Promise<TsoaResponse<OrderListResponseDto>> {
+    const payload = req.user;
+    const userId = payload.id;
+    // console.log(userId);
+    const dto = new OrderRequestDto(type, cursor, limit, userId, OnlyReviewAvailable, order); 
+    const { orders, nextCursor, hasNext } = await this.profileService.getOrders(dto);
+    const ordersRes = orders.map((o) => o.toResponse());
+    const res: OrderListResponseDto = {
+      orders: ordersRes,
+      nextCursor,
+      hasNext
+    };
     return new ResponseHandler(res);
   }
 

--- a/src/routes/profile/profile.error.ts
+++ b/src/routes/profile/profile.error.ts
@@ -35,3 +35,9 @@ export class OwnerNotFound extends BasicError {
     super(404, 'OWNER-NOT-FOUND', '프로필을 찾을 수 없습니다.', `Owner ID: ${ownerId}`);
   }
 }
+
+export class ForbiddenAccessError extends BasicError {
+  constructor(orderId: string) {
+    super(403, 'NO-AUTH', '해당 주문 정보를 조회할 권한이 없습니다', `Order ID : ${orderId}`)
+  }
+}

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -294,8 +294,12 @@ export class Order {
   }
 
   static create(raw: RawOrderData, title: string, thumbnail: string): Order {
-    const totalPrice = raw.price!.toNumber() + raw.delivery_fee!.toNumber();
-    const reviewAvailable = raw.status !== 'PENDING' && raw.review[0]?.review_id ? false : true;
+    const price = raw.price ? raw.price.toNumber() : 0;
+    const delivery_fee = raw.delivery_fee ? raw.delivery_fee.toNumber() : 0;
+    const totalPrice = (price + delivery_fee) ? (price + delivery_fee).toString() : '0' ;
+    const isPending = raw.status === 'PENDING';
+    const hasReview = raw.review.length > 0;
+    const reviewAvailable = !isPending && !hasReview;
     return new Order({
       receiptNumber: raw.receipt.receipt_number!,
       title: title,
@@ -303,20 +307,13 @@ export class Order {
       orderId: raw.order_id as UUID,
       targetId: raw.target_id as UUID,
       status: raw.status!,
-      price: raw.price!.toNumber(),
-      deliveryFee: raw.delivery_fee!.toNumber(),
-      totalPrice: totalPrice.toString(),
-      targetType: raw.target_type!,
-      quantity: raw.quantity!,
-      trackingNumber: raw.tracking_number!,
-      ownerNickname: raw.owner.nickname!,
+      price: price,
+      deliveryFee: delivery_fee,
+      totalPrice: totalPrice,
+      targetType: raw.target_type ?? 'ITEM',
+      quantity: raw.quantity ?? 1,
+      ownerNickname: raw.owner.nickname ?? '',
       createdAt: raw.receipt.created_at ?? new Date(),
-      deliveryAddress: raw.receipt.delivery_address!,
-      deliveryAddressDetail: raw.receipt.delivery_address_detail!,
-      deliveryAddressName: raw.receipt.delivery_address_name!,
-      deliveryPhone: raw.receipt.delivery_phone!,
-      deliveryPostalCode: raw.receipt.delivery_postal_code!,
-      deliveryRecipientName: raw.receipt.delivery_recipient_name!,
       reviewAvailable: reviewAvailable,
       reviewId: raw.review[0]?.review_id ?? null
     });
@@ -374,7 +371,9 @@ export class OrderDetail {
   }
 
   static create(raw: RawOrderDetailData, title: string | undefined, thumbnail: string | undefined, options : RawOptionItemsWithGroup[]): OrderDetail {
-    const totalPrice = (raw.price!.toNumber() + raw.delivery_fee!.toNumber()).toString();
+    const price = raw.price ? raw.price.toNumber() : 0;
+    const delivery_fee = raw.delivery_fee ? raw.delivery_fee.toNumber() : 0;
+    const totalPrice = (price + delivery_fee) ? (price + delivery_fee).toString() : '0' ;
     return new OrderDetail({
       title: title ?? '',
       thumbnail: thumbnail ?? '',
@@ -382,8 +381,8 @@ export class OrderDetail {
       targetType: raw.target_type!,
       targetId: raw.target_id!,
       status: raw.status ?? 'PENDING',
-      price: raw.price!.toNumber()!,
-      deliveryFee: raw.delivery_fee!.toNumber(),
+      price: price,
+      deliveryFee: delivery_fee,
       totalPrice: totalPrice,
       trackingNumber: raw.tracking_number ?? '',
       createdAt: raw.receipt.created_at ?? new Date(),

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -3,7 +3,8 @@ import { UUID } from '../../@types/common.js';
 import {
   SaleDetailResponseDto,
   SaleResponseDto,
-  OrderResponseDto
+  OrderResponseDto,
+  OrderDetailResponseDto
 } from './dto/profile.res.dto.js';
 import {
   AddItemRequestDto,
@@ -316,7 +317,7 @@ export class Order {
       deliveryPhone: raw.receipt.delivery_phone!,
       deliveryPostalCode: raw.receipt.delivery_postal_code!,
       deliveryRecipientName: raw.receipt.delivery_recipient_name!,
-      reviewAvailable: raw.review[0]?.review_id ? true : false,
+      reviewAvailable: reviewAvailable,
       reviewId: raw.review[0]?.review_id ?? null
     });
   }
@@ -324,4 +325,80 @@ export class Order {
   toResponse(): OrderResponseDto {
     return { ...this.props };
   }
+}
+
+export type RawOrderDetailData = Prisma.orderGetPayload<{
+  select: {
+    order_id: true;
+    user_id: true;
+    target_id: true;
+    status: true;
+    price: true;
+    delivery_fee: true;
+    target_type: true;
+    tracking_number: true;
+    receipt: {
+      select: {
+        created_at: true;
+        receipt_number: true;
+        delivery_address: true;
+        delivery_address_detail: true;
+        delivery_address_name: true;
+        delivery_phone: true;
+        delivery_postal_code: true;
+        delivery_recipient_name: true;
+      };
+    };
+  };
+}>;
+
+export type RawOptionItemsWithGroup = {
+  option_group_id: string;
+  name: string | null;
+  option_item: RawOptionItem[]
+}
+
+export type RawOptionItem = {
+  name: string | null;
+  option_item_id: string;
+  extra_price: number | null;
+}
+
+
+
+export class OrderDetail {
+  private props: OrderDetailResponseDto;
+
+  private constructor(props: OrderDetailResponseDto) {
+    this.props = props;
+  }
+
+  static create(raw: RawOrderDetailData, title: string | undefined, thumbnail: string | undefined, options : RawOptionItemsWithGroup[]): OrderDetail {
+    const totalPrice = (raw.price!.toNumber() + raw.delivery_fee!.toNumber()).toString();
+    return new OrderDetail({
+      title: title ?? '',
+      thumbnail: thumbnail ?? '',
+      orderId: raw.order_id,
+      targetType: raw.target_type!,
+      targetId: raw.target_id!,
+      status: raw.status ?? 'PENDING',
+      price: raw.price!.toNumber()!,
+      deliveryFee: raw.delivery_fee!.toNumber(),
+      totalPrice: totalPrice,
+      trackingNumber: raw.tracking_number ?? '',
+      createdAt: raw.receipt.created_at ?? new Date(),
+      receiptNumber: raw.receipt.receipt_number ?? '',
+      deliveryPostalCode: raw.receipt.delivery_postal_code ?? '',
+      deliveryAddress: raw.receipt.delivery_address ?? '',
+      deliveryAddressDetail: raw.receipt.delivery_address_detail ?? '',
+      deliveryRecipientName: raw.receipt.delivery_recipient_name ?? '',
+      deliveryPhone: raw.receipt.delivery_phone ?? '',
+      deliveryAddressName: raw.receipt.delivery_address_name ?? '',
+      options : options
+    });
+  }
+
+  toResponse(): OrderDetailResponseDto {
+    return { ...this.props };
+  }  
 }

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -296,7 +296,7 @@ export class Order {
     const hasReview = raw.review.length > 0;
     const reviewAvailable = !isPending && !hasReview;
     return new Order({
-      receiptNumber: raw.receipt.receipt_number!,
+      receiptNumber: raw.receipt?.receipt_number ?? '',
       title: title,
       thumbnail: thumbnail,
       orderId: raw.order_id as UUID,
@@ -308,7 +308,7 @@ export class Order {
       totalPrice: totalPrice,
       quantity: raw.quantity ?? 1,
       ownerNickname: raw.owner.nickname ?? '',
-      createdAt: raw.receipt.created_at ?? new Date(),
+      createdAt: raw.receipt?.created_at ?? new Date(),
       reviewAvailable: reviewAvailable,
       reviewId: raw.review[0]?.review_id ?? null
     });
@@ -380,14 +380,14 @@ export class OrderDetail {
       deliveryFee: delivery_fee,
       totalPrice: totalPrice,
       trackingNumber: raw.tracking_number ?? '',
-      createdAt: raw.receipt.created_at ?? new Date(),
-      receiptNumber: raw.receipt.receipt_number ?? '',
-      deliveryPostalCode: raw.receipt.delivery_postal_code ?? '',
-      deliveryAddress: raw.receipt.delivery_address ?? '',
-      deliveryAddressDetail: raw.receipt.delivery_address_detail ?? '',
-      deliveryRecipientName: raw.receipt.delivery_recipient_name ?? '',
-      deliveryPhone: raw.receipt.delivery_phone ?? '',
-      deliveryAddressName: raw.receipt.delivery_address_name ?? '',
+      createdAt: raw.receipt?.created_at ?? new Date(),
+      receiptNumber: raw.receipt?.receipt_number ?? '',
+      deliveryPostalCode: raw.receipt?.delivery_postal_code ?? '',
+      deliveryAddress: raw.receipt?.delivery_address ?? '',
+      deliveryAddressDetail: raw.receipt?.delivery_address_detail ?? '',
+      deliveryRecipientName: raw.receipt?.delivery_recipient_name ?? '',
+      deliveryPhone: raw.receipt?.delivery_phone ?? '',
+      deliveryAddressName: raw.receipt?.delivery_address_name ?? '',
       options : options
     });
   }

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -305,12 +305,12 @@ export class Order {
       title: title,
       thumbnail: thumbnail,
       orderId: raw.order_id as UUID,
+      targetType: raw.target_type ?? 'ITEM',
       targetId: raw.target_id as UUID,
       status: raw.status!,
       price: price,
       deliveryFee: delivery_fee,
       totalPrice: totalPrice,
-      targetType: raw.target_type ?? 'ITEM',
       quantity: raw.quantity ?? 1,
       ownerNickname: raw.owner.nickname ?? '',
       createdAt: raw.receipt.created_at ?? new Date(),
@@ -400,4 +400,35 @@ export class OrderDetail {
   toResponse(): OrderDetailResponseDto {
     return { ...this.props };
   }  
+}
+
+export type RawRequestData = Prisma.reform_requestGetPayload<{
+  select: {
+    reform_request_id: true;
+    user_id: true;
+    title: true;
+    min_budget: true;
+    max_budget: true;
+    due_date: true;
+    created_at: true;
+    reform_request_photo: {
+      select: {
+        reform_request_photo_id: true;
+        content: true;
+      };
+      take: 1;
+    };
+  };
+}>;
+
+export type RequestData = {
+  reformRequestId:UUID;
+  userId: UUID;
+  title: string;
+  minBudget: number | null;
+  maxBudget: number | null;
+  dueDate: Date | null;
+  createdAt: Date | null;
+  reformRequestPhotoId: UUID;
+  thumbnail: string | null;
 }

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -2,7 +2,8 @@ import { Prisma, order_status_enum } from '@prisma/client';
 import { UUID } from '../../@types/common.js';
 import {
   SaleDetailResponseDto,
-  SaleResponseDto
+  SaleResponseDto,
+  OrderResponseDto
 } from './dto/profile.res.dto.js';
 import {
   AddItemRequestDto,
@@ -245,6 +246,82 @@ export class Reform {
   }
 
   toDto(): ReformDto {
+    return { ...this.props };
+  }
+}
+
+export type RawOrderData = Prisma.orderGetPayload<{
+  select: {
+    order_id: true;
+    target_id: true;
+    status: true;
+    price: true;
+    delivery_fee: true;
+    target_type: true;
+    quantity: true;
+    tracking_number: true;
+    owner: {
+      select: {
+        nickname: true;
+      };
+    };
+    receipt: {
+      select: {
+        created_at: true;
+        receipt_number: true;
+        delivery_address: true;
+        delivery_address_detail: true;
+        delivery_address_name: true;
+        delivery_phone: true;
+        delivery_postal_code: true;
+        delivery_recipient_name: true;
+      };
+    };
+    review: {
+      select: {
+        review_id: true;
+      };
+    };
+  };
+}>;
+
+export class Order {
+  private props: OrderResponseDto;
+
+  private constructor(props: OrderResponseDto) {
+    this.props = props;
+  }
+
+  static create(raw: RawOrderData, title: string, thumbnail: string): Order {
+    const totalPrice = raw.price!.toNumber() + raw.delivery_fee!.toNumber();
+    const reviewAvailable = raw.status !== 'PENDING' && raw.review[0]?.review_id ? false : true;
+    return new Order({
+      receiptNumber: raw.receipt.receipt_number!,
+      title: title,
+      thumbnail: thumbnail,
+      orderId: raw.order_id as UUID,
+      targetId: raw.target_id as UUID,
+      status: raw.status!,
+      price: raw.price!.toNumber(),
+      deliveryFee: raw.delivery_fee!.toNumber(),
+      totalPrice: totalPrice.toString(),
+      targetType: raw.target_type!,
+      quantity: raw.quantity!,
+      trackingNumber: raw.tracking_number!,
+      ownerNickname: raw.owner.nickname!,
+      createdAt: raw.receipt.created_at ?? new Date(),
+      deliveryAddress: raw.receipt.delivery_address!,
+      deliveryAddressDetail: raw.receipt.delivery_address_detail!,
+      deliveryAddressName: raw.receipt.delivery_address_name!,
+      deliveryPhone: raw.receipt.delivery_phone!,
+      deliveryPostalCode: raw.receipt.delivery_postal_code!,
+      deliveryRecipientName: raw.receipt.delivery_recipient_name!,
+      reviewAvailable: raw.review[0]?.review_id ? true : false,
+      reviewId: raw.review[0]?.review_id ?? null
+    });
+  }
+
+  toResponse(): OrderResponseDto {
     return { ...this.props };
   }
 }

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -4,7 +4,7 @@
 import prisma from '../../config/prisma.config.js';
 import { PrismaClient } from '@prisma/client/extension';
 import { CategoryNotExist } from './profile.error.js';
-import { OrderRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
+import { OrderRequestDto, RequestListRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
 import {
   Item,
   ItemDto,
@@ -15,7 +15,9 @@ import {
   ReformDto,
   RawOrderData,
   RawOrderDetailData,
-  RawOptionItemsWithGroup
+  RawOptionItemsWithGroup,
+  RequestData,
+  RawRequestData
 } from './profile.model.js';
 import { OptionGroup } from '../../@types/item.js';
 import { target_type_enum } from '@prisma/client';
@@ -658,5 +660,56 @@ export class ProfileRepository {
         }
       }
     })
+  }
+
+  async getRequestsByUserId(dto: RequestListRequestDto): Promise<RequestData[]> {
+    const { cursor, limit, userId, order } = dto;
+    const requests: RawRequestData[] = await this.prisma.reform_request.findMany({
+      where: {
+        user_id: userId
+      },
+      take: limit + 1,
+      skip: cursor ? 1 : 0,
+      cursor: cursor ? { reform_request_id : cursor } : undefined,
+      orderBy: [
+        { created_at: order },
+        { reform_request_id: order }
+      ],
+      select: {
+        reform_request_id: true,
+        user_id: true,
+        title: true,
+        min_budget: true,
+        max_budget: true,
+        due_date: true,
+        created_at: true,
+        reform_request_photo: {
+          select: {
+            reform_request_photo_id: true,
+            content: true,
+          },
+          orderBy:  [
+              { photo_order: 'asc' },
+              { reform_request_photo_id : 'asc'}
+            ],
+          take: 1
+        }
+      }
+    })
+    return requests.map((request) => {
+      const photo = request.reform_request_photo[0];
+
+      return {
+        reformRequestId: request.reform_request_id,
+        userId: request.user_id ?? userId,
+        title: request.title ?? '',
+        minBudget: request.min_budget ? Number(request.min_budget) : null,
+        maxBudget: request.max_budget ? Number(request.max_budget) : null,
+        dueDate: request.due_date,
+        createdAt: request.created_at,
+        reformRequestPhotoId: photo?.reform_request_photo_id ?? null,
+        thumbnail: photo?.content ?? '' 
+      };
+    });
   }
 }

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -13,7 +13,9 @@ import {
   RawSaleDetailData,
   Reform,
   ReformDto,
-  RawOrderData
+  RawOrderData,
+  RawOrderDetailData,
+  RawOptionItemsWithGroup
 } from './profile.model.js';
 import { OptionGroup } from '../../@types/item.js';
 import { target_type_enum } from '@prisma/client';
@@ -583,5 +585,78 @@ export class ProfileRepository {
       }
     });
     return orders;
+  }
+
+  async getOrderDetailByOrderId(orderId: string): Promise<RawOrderDetailData> {
+    return await prisma.order.findFirstOrThrow({
+      where: { order_id: orderId },
+      select: {
+        order_id: true,
+        user_id: true,
+        target_type: true,
+        target_id: true,
+        status: true,
+        price: true,
+        delivery_fee: true,
+        tracking_number: true,
+        receipt: {
+          select: {
+            created_at: true,
+            receipt_number: true,
+            delivery_address: true,
+            delivery_address_detail: true,
+            delivery_address_name: true,
+            delivery_phone: true,
+            delivery_postal_code: true,
+            delivery_recipient_name: true,
+          }
+        },
+      }
+    })
+  }
+
+  async getOptionIdsByOrderId(orderId: string): Promise<string[]> {
+    const optionIds = await prisma.order_option.findMany({
+      where: { order_id: orderId },
+      orderBy: [
+        {
+          option_item: {
+            sort_order: 'asc'
+          }
+        }
+      ],
+      select: {
+        option_item: {
+          select: {
+            option_item_id: true
+          }
+        }
+      },
+    });
+    return optionIds.map((optionId: (typeof optionIds)[number]) => 
+      optionId.option_item.option_item_id)
+  }
+
+  async getOptionItemsWithGroup(optionItemIds: string[] | undefined ): Promise<RawOptionItemsWithGroup[]> {
+    return await prisma.option_group.findMany({
+      orderBy: {
+        sort_order: 'asc'
+      },
+      select: {
+        option_group_id: true,
+        name: true,
+        option_item: {
+          where: { option_item_id: { in: optionItemIds } },
+          orderBy: {
+            sort_order: 'asc'
+          },
+          select: {
+            option_item_id: true,
+            name: true,
+            extra_price: true
+          }
+        }
+      }
+    })
   }
 }

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -4,7 +4,7 @@
 import prisma from '../../config/prisma.config.js';
 import { PrismaClient } from '@prisma/client/extension';
 import { CategoryNotExist } from './profile.error.js';
-import { SaleRequestDto } from './dto/profile.req.dto.js';
+import { OrderRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
 import {
   Item,
   ItemDto,
@@ -12,9 +12,11 @@ import {
   RawSaleData,
   RawSaleDetailData,
   Reform,
-  ReformDto
+  ReformDto,
+  RawOrderData
 } from './profile.model.js';
 import { OptionGroup } from '../../@types/item.js';
+import { target_type_enum } from '@prisma/client';
 
 export class ProfileRepository {
   private prisma: PrismaClient;
@@ -261,6 +263,27 @@ export class ProfileRepository {
     }));
   }
 
+  async getRequestInfos(requestIds: string[]) {
+    if (requestIds.length === 0) return [];
+    const requests = await this.prisma.reform_request.findMany({
+      where: { reform_request_id: { in: requestIds } },
+      select: {
+        reform_request_id: true,
+        title: true,
+        min_budget: true,
+        max_budget: true,
+        reform_request_photo: { select: { content: true }, orderBy: { photo_order: 'asc' }, take: 1 }
+      }
+    });
+    return requests.map((request: (typeof requests)[number]) => ({
+      reform_request_id: request.reform_request_id,
+      title: request.title,
+      minBudget: request.min_budget !== null ? Number(request.min_budget) : null,
+      maxBudget: request.max_budget !== null ? Number(request.max_budget) : null,
+      photo: request.reform_request_photo[0]?.content ?? null
+    }));
+  }
+
   async getOrderDetail(
     ownerId: string,
     orderId: string
@@ -498,5 +521,67 @@ export class ProfileRepository {
         profile_photo: true
       }
     });
+  }
+
+  async getOrdersByUserId(dto: OrderRequestDto): Promise<RawOrderData[]> {
+    const { userId, type, cursor, limit, order, onlyReviewAvailable } = dto;
+    const targetTypeFilter = {
+      REFORM: { in: ['REQUEST', 'PROPOSAL'] },
+      ITEM: 'ITEM',
+      ALL: undefined
+    };
+    const whereClause : any = {
+      user_id: userId,
+      target_type: targetTypeFilter[type as keyof typeof targetTypeFilter] as target_type_enum | undefined
+    };
+    
+    if (onlyReviewAvailable) {
+      whereClause.review = { none: {} };
+      whereClause.status = { not: 'PENDING' };
+    }
+
+    const orders = await this.prisma.order.findMany({
+      where: whereClause,
+      take: limit + 1,
+      skip: cursor ? 1 : 0,
+      cursor: cursor ? { order_id: cursor } : undefined,
+      orderBy: [
+        { created_at: order },
+        { order_id: order }
+      ],
+      select: {
+        order_id: true,
+        target_id: true,
+        status: true,
+        price: true,
+        delivery_fee: true,
+        target_type: true,
+        quantity: true,
+        tracking_number: true,
+        owner: {
+          select: {
+            nickname: true
+          }
+        },
+        receipt: {
+          select: {
+            created_at: true,
+            receipt_number: true,
+            delivery_address: true,
+            delivery_address_detail: true,
+            delivery_address_name: true,
+            delivery_phone: true,
+            delivery_postal_code: true,
+            delivery_recipient_name: true,
+          }
+        },
+        review: {
+          select: {
+            review_id: true,
+          }
+        }
+      }
+    });
+    return orders;
   }
 }

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -548,8 +548,14 @@ export class ProfileRepository {
       skip: cursor ? 1 : 0,
       cursor: cursor ? { order_id: cursor } : undefined,
       orderBy: [
-        { created_at: order },
-        { order_id: order }
+        {
+          receipt: {
+            created_at: order
+          }
+        },
+        {
+          order_id: order
+        }
       ],
       select: {
         order_id: true,
@@ -568,13 +574,7 @@ export class ProfileRepository {
         receipt: {
           select: {
             created_at: true,
-            receipt_number: true,
-            delivery_address: true,
-            delivery_address_detail: true,
-            delivery_address_name: true,
-            delivery_phone: true,
-            delivery_postal_code: true,
-            delivery_recipient_name: true,
+            receipt_number: true
           }
         },
         review: {

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -471,7 +471,7 @@ export class ProfileService {
   }
 
   // 주문 목록 조회
-  async getOrders(dto: OrderRequestDto): Promise<Order[]> {
+  async getOrders(dto: OrderRequestDto): Promise<{ orders: Order[], nextCursor: string | null, hasNext: boolean }> {
     // 1. 초기 조건에 맞는 주문 목록 조회
     const orders = await this.profileRepository.getOrdersByUserId(dto);
     
@@ -516,8 +516,13 @@ export class ProfileService {
     return Order.create(order, info.title, info.thumbnail);
   });
 
-  // 6. 주문 타입 별로 필터링
-  return ordersPreview
+  const nextCursor = hasNext ? actualOrders[actualOrders.length - 1].order_id : null;
+
+  return {
+    orders: ordersPreview,
+    nextCursor,
+    hasNext
+    };
   }
 
   async getOrderDetail(userId: string, orderId: string): Promise<OrderDetailResponseDto> {

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -5,10 +5,11 @@ import {
   OrderItemError,
   OwnerNotFound
 } from './profile.error.js';
-import { AddFeedRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
+import { AddFeedRequestDto, OrderRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
 import {
   Item,
   ItemDto,
+  Order,
   Reform,
   ReformDto,
   Sale,
@@ -461,5 +462,55 @@ export class ProfileService {
       nextCursor,
       hasNext
     };
+  }
+
+  // 주문 목록 조회
+  async getOrders(dto: OrderRequestDto): Promise<Order[]> {
+    // 1. 초기 조건에 맞는 주문 목록 조회
+    const orders = await this.profileRepository.getOrdersByUserId(dto);
+    
+    // 1.1 다음 페이지 여부 확인
+    const hasNext = orders.length > dto.limit;
+    const actualOrders = hasNext ? orders.slice(0, dto.limit) : orders;
+    
+    // 2. ID 수집 (Set을 사용해 중복 제거)
+    const itemIds = new Set<string>();
+    const requestIds = new Set<string>();
+    const proposalIds = new Set<string>();
+
+    actualOrders.forEach(o => {
+      if (!o.target_id) return;
+      if (o.target_type === 'ITEM') itemIds.add(o.target_id);
+      else if (o.target_type === 'REQUEST') requestIds.add(o.target_id);
+      else if (o.target_type === 'PROPOSAL') proposalIds.add(o.target_id);
+    });
+
+    
+    // 3. title 과 thumbnail(photo) 조회
+    const [itemInfos, reqInfos, propInfos] = await Promise.all([
+      this.profileRepository.getItemInfos(Array.from(itemIds)),
+      this.profileRepository.getRequestInfos(Array.from(requestIds)),
+      this.profileRepository.getProposalInfos(Array.from(proposalIds))
+    ]);
+
+    const infoMap = new Map<string, { title: string, thumbnail: string }>();
+    const addToMap = (list: any[], idKey: string) => {
+      list.forEach(data => {
+        infoMap.set(data[idKey], { title: data.title, thumbnail: data.photo });
+      });
+    };
+
+    addToMap(itemInfos, 'item_id');
+    addToMap(reqInfos, 'reform_request_id');
+    addToMap(propInfos, 'reform_proposal_id');
+
+  // 4. 모든 주문 목록 preview 생성
+  const ordersPreview = actualOrders.map((order) => {
+    const info = infoMap.get(order.target_id ?? '') ?? { title: '', thumbnail: '' };
+    return Order.create(order, info.title, info.thumbnail);
+  });
+
+  // 6. 주문 타입 별로 필터링
+  return ordersPreview
   }
 }

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -3,8 +3,12 @@ import {
   CategoryNotExist,
   ItemAddError,
   OrderItemError,
-  OwnerNotFound
+  OwnerNotFound,
+  ForbiddenAccessError
 } from './profile.error.js';
+import {
+  OrderNotFoundError
+} from '../orders/orders.error.js';
 import { AddFeedRequestDto, OrderRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
 import {
   Item,
@@ -13,7 +17,8 @@ import {
   Reform,
   ReformDto,
   Sale,
-  SaleDetail
+  SaleDetail,
+  OrderDetail
 } from './profile.model.js';
 import type {
   AddFeedResponseDto,
@@ -21,7 +26,8 @@ import type {
   FeedListResponse,
   MarketListResponse,
   ProposalListResponse,
-  ReviewListResponse
+  ReviewListResponse,
+  OrderDetailResponseDto
 } from './dto/profile.res.dto.js';
 export class ProfileService {
   private profileRepository: ProfileRepository;
@@ -512,5 +518,45 @@ export class ProfileService {
 
   // 6. 주문 타입 별로 필터링
   return ordersPreview
+  }
+
+  async getOrderDetail(userId: string, orderId: string): Promise<OrderDetailResponseDto> {
+    //1. 주문 조회
+    const order = await this.profileRepository.getOrderDetailByOrderId(orderId);
+    if (!order) {
+      throw new OrderNotFoundError(orderId)
+    }
+    if (order.user_id !== userId){
+      throw new ForbiddenAccessError(orderId)
+    }
+
+    // 2. 옵션 조회
+    const [info, optionItemIds] = await Promise.all([
+      this.getTargetInfo(order.target_type, order.target_id),
+      this.profileRepository.getOptionIdsByOrderId(orderId)
+    ])
+    const optionItemsWithGroup = await this.profileRepository.getOptionItemsWithGroup(optionItemIds);
+    
+    // 3. 결과값 리턴
+    const orderDetail = OrderDetail.create(order,info?.title, info?.thumbnail, optionItemsWithGroup)
+    return orderDetail.toResponse()
+  }
+
+  private async getTargetInfo(type: string | null, id: string | null) {
+    if (!type || !id) return undefined;
+  
+    switch (type) {
+      case 'ITEM':
+        const items = await this.profileRepository.getItemInfos([id]);
+        return items[0] ? { title: items[0].title ?? '', thumbnail: items[0].photo ?? ''} : undefined;
+      case 'PROPOSAL':
+        const proposals = await this.profileRepository.getProposalInfos([id]);
+        return proposals[0] ? { title: proposals[0].title ?? '', thumbnail: proposals[0].photo ?? ''} : undefined;
+      case 'REQUEST':
+        const requests = await this.profileRepository.getRequestInfos([id]);
+        return requests[0] ? { title: requests[0].title ?? '', thumbnail: requests[0].photo ?? ''} : undefined;
+      default:
+        return undefined;
+    }
   }
 }

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -9,7 +9,7 @@ import {
 import {
   OrderNotFoundError
 } from '../orders/orders.error.js';
-import { AddFeedRequestDto, OrderRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
+import { AddFeedRequestDto, OrderRequestDto, RequestListRequestDto, SaleRequestDto } from './dto/profile.req.dto.js';
 import {
   Item,
   ItemDto,
@@ -18,7 +18,7 @@ import {
   ReformDto,
   Sale,
   SaleDetail,
-  OrderDetail
+  OrderDetail,
 } from './profile.model.js';
 import type {
   AddFeedResponseDto,
@@ -27,7 +27,8 @@ import type {
   MarketListResponse,
   ProposalListResponse,
   ReviewListResponse,
-  OrderDetailResponseDto
+  OrderDetailResponseDto,
+  RequestsListResponseDto
 } from './dto/profile.res.dto.js';
 export class ProfileService {
   private profileRepository: ProfileRepository;
@@ -562,6 +563,19 @@ export class ProfileService {
         return requests[0] ? { title: requests[0].title ?? '', thumbnail: requests[0].photo ?? ''} : undefined;
       default:
         return undefined;
+    }
+  }
+  
+
+  async getRequests(dto: RequestListRequestDto): Promise< RequestsListResponseDto >{
+    const requests = await this.profileRepository.getRequestsByUserId(dto);
+    const hasNext = requests.length > dto.limit;
+    const actualRequests = hasNext ? requests.slice(0, dto.limit) : requests
+    const nextCursor = hasNext ? actualRequests[actualRequests.length - 1].reformRequestId : null
+    return {
+      requestData: actualRequests,
+      nextCursor,
+      hasNext
     }
   }
 }

--- a/src/routes/reform/reform.controller.ts
+++ b/src/routes/reform/reform.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Example,
   Get,
   Patch,
@@ -170,6 +171,24 @@ export class ReformController extends Controller {
     return new ResponseHandler(ans);
   }
 
+    /**
+   * @summary 특정 리폼 요청을 삭제합니다.
+   * @param id 삭제하려는 리폼 요청글 ID (UUID)
+   * @returns 리폼 요청 삭제 성공 여부
+   */
+    @Delete('/request/:id')
+    @Security('jwt')
+    @SuccessResponse(200, '삭제 성공')
+    public async deleteRequest(
+      @Path() id: string,
+      @Request() req: ExRequest
+    ): Promise<TsoaResponse<string>> {
+      const payload = req.user;
+      const userId = payload.id;
+      const ans = await this.reformService.deleteRequest(id, userId);
+      return new ResponseHandler(ans);
+    }
+    
   /**
    * @summary 요청서 목록을 보여줍니다.
    * @param sortBy 정렬 기준

--- a/src/routes/reform/reform.repository.ts
+++ b/src/routes/reform/reform.repository.ts
@@ -418,6 +418,24 @@ export class ReformRepository {
     return result;
   }
 
+  async deleteRequestPhotos(requestId: string){
+  await this.prisma.reform_request_photo.deleteMany({
+    where: { 
+      reform_request_id : requestId 
+      }
+    })
+  }
+
+  async deleteRequest(requestId: string, userId: string){
+    await this.prisma.reform_request.deleteMany({
+      where: {
+        reform_request_id : requestId,
+        user_id : userId
+      }
+    })
+  }
+  
+
   async updateProposal(
     dto: ReformProposalUpdate,
     categoryId?: UUID

--- a/src/routes/reform/reform.service.ts
+++ b/src/routes/reform/reform.service.ts
@@ -21,6 +21,7 @@ import { addSearchSyncJob } from '../../worker/search.queue.js';
 import { CustomJwt } from '../../@types/expreees.js';
 import { runInThisContext } from 'vm';
 import { runInTransaction } from '../../config/prisma.config.js';
+import { UUID } from 'crypto';
 
 export class ReformService {
   private reformRepository: ReformRepository;
@@ -201,6 +202,29 @@ export class ReformService {
       return ans;
     } catch (err: any) {
       throw new ReformError(err);
+    }
+  }
+
+  async deleteRequest(requestId: string, userId: string): Promise<string> {
+    const isOwner = await this.reformRepository.checkRequestOwner(
+      userId,
+      requestId
+    );
+    if (!isOwner)
+      throw new ReformError('본인의 요청서만 삭제할 수 있습니다.');
+
+    try {
+      return await runInTransaction(async () => {
+        await this.reformRepository.deleteRequestPhotos(requestId);
+        await this.reformRepository.deleteRequest(
+          requestId,
+          userId
+        );
+        return '요청글이 성공적으로 삭제되었습니다.'
+      });
+      } catch (err: any) {
+        console.error(`[DeleteRequest Error] ID: ${requestId}`, err);
+        throw new ReformError('요청글 삭제 중 오류가 발생했습니다.');
     }
   }
 


### PR DESCRIPTION
## 개요

사용자의 리폼 요청 글을 조회 및 삭제, 구매 이력 및 세부 정보를 조회하는 기능을 구현합니다.

## 주요 변경 사항

- [ ] GET profile/requests : 리폼 요청 글을 조회합니다.
- [ ] GET /profile/orders : 구매 이력을 조회합니다. (마켓/리폼 + 리뷰 가능 여부 구분)
- [ ] GET /profile/orders/{id} : 구매 내역을 상세하게 조회합니다
- [ ] DELETE /reform/request/{id} : 자신이 작성한 리폼 요청글을 삭제합니다.

## 관련 이슈/마일스톤

- Closes #77 
- Relates to #77 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
