### PR TITLE
Feat : 일반 유저 프로필 불러오기 기능 구현

### DIFF
--- a/src/routes/users/dto/users.res.dto.ts
+++ b/src/routes/users/dto/users.res.dto.ts
@@ -107,3 +107,13 @@ export class ReformerDetailInfoResponseDto {
     this.totalSales = props.trade_count ?? 0;
   }
 }
+
+export interface UserProfileResponseDto{
+  userId: string,
+  email: string,
+  name: string,
+  nickName: string,
+  phone: string,
+  profilePhoto: string,
+  role: Role
+}

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -1,10 +1,26 @@
-import { Body, Path, Post, Patch, Controller, Route, Tags, Query, SuccessResponse, Example, Response, Request, Security, Get } from 'tsoa';
+import { 
+  Body,
+  Path, 
+  Post, 
+  Patch, 
+  Controller, 
+  Route, 
+  Tags, 
+  Query, 
+  SuccessResponse, 
+  Example, 
+  Response, 
+  Request, 
+  Security, 
+  Get 
+} from 'tsoa';
 import { ErrorResponse, ResponseHandler, TsoaResponse } from '../../config/tsoaResponse.js';
-import { CheckNicknameResponse, UpdateReformerProfileResponseDto, UsersInfoResponse } from './dto/users.res.dto.js';
+import { CheckNicknameResponse, UpdateReformerProfileResponseDto, UserProfileResponseDto, UsersInfoResponse } from './dto/users.res.dto.js';
 import { UpdateReformerStatusRequest, UpdateUserProfileRequestDto, UpdateReformerProfileRequestDto } from './dto/users.req.dto.js';
 import { UpdateUserProfileResponseDto, UserDetailInfoResponseDto, ReformerDetailInfoResponseDto } from './dto/users.res.dto.js';
 import { UsersService } from './users.service.js';
 import { UnauthorizedError } from '../auth/auth.error.js';
+import { Request as ExRequest } from 'express';
 
 @Route('users')
 @Tags('Users')
@@ -167,5 +183,37 @@ export class UsersController extends Controller {
       result = await this.usersService.getReformerDetailInfo(userId);
     }
     return new ResponseHandler<UserDetailInfoResponseDto | ReformerDetailInfoResponseDto>(result);
+  }
+
+  /**
+   * 일반 유저 프로필 내용 불러오기
+   * @summary 일반 유저의 프로필 내용을 불러옵니다.
+   * @returns 유저 프로필 내용
+   */
+  @Security('jwt', ['user'])
+  @SuccessResponse(200, '유저 프로필 조회 성공')
+  @Response<ErrorResponse>('404', '존재하지 않는 계정 조회 시도')
+  @Example<ResponseHandler<UserDetailInfoResponseDto>>({
+    resultType: 'SUCCESS',
+    error: null,
+    success: {
+      userId: '123e4567-e89b-12d3-a456-426614174000',
+      email: 'user@example.com',
+      name: '홍길동',
+      nickname: 'nickname',
+      phone: '01012345678',
+      role: 'user',
+      profileImageUrl: 'https://myform-reform.s3.ap-northeast-2.amazonaws.com/profileImages/1234567890.jpg',
+    }
+  })
+  @Get('user/me/profile')
+  public async getUserProfile(
+    @Request() req: ExRequest
+  ): Promise<TsoaResponse<UserProfileResponseDto>> {
+    const payload = req.user;
+    const userId = payload.id;
+    const userProfile =  await this.usersService.getUserProfile(userId);
+    const userProfileDto = userProfile.toDto();
+    return new ResponseHandler<UserProfileResponseDto>(userProfileDto);
   }
 }

--- a/src/routes/users/users.model.ts
+++ b/src/routes/users/users.model.ts
@@ -1,8 +1,8 @@
 import prisma from '../../config/prisma.config.js';
-import { UsersInfoResponse } from './dto/users.res.dto.js';
+import { UpdateUserProfileResponseDto, UsersInfoResponse, UserProfileResponseDto } from './dto/users.res.dto.js';
 import { UpdateReformerStatusRequest } from './dto/users.req.dto.js';
 import { account_role, owner, provider_type, social_account, user } from '@prisma/client';
-
+import { Prisma } from '@prisma/client';
 export class UsersModel {
   private prisma;
 
@@ -191,5 +191,40 @@ export class UsersModel {
       }
     }
     return null;
+  }
+}
+
+export type RawUserPorfile = Prisma.userGetPayload<{
+  select: {
+    user_id: true,
+    email: true,
+    name: true,
+    nickname: true,
+    phone: true,
+    profile_photo: true
+  }
+}>
+
+export class UserProfile {
+  private props: UserProfileResponseDto
+
+  private constructor(props: UserProfileResponseDto) {
+    this.props = props;
+  }
+
+  static create(raw: RawUserPorfile): UserProfile {
+    return new UserProfile({
+      userId: raw.user_id,
+      email: raw.email ?? '',
+      name: raw.name ?? '',
+      nickName: raw.nickname ?? '',
+      phone: raw.phone ?? '',
+      profilePhoto: raw.profile_photo ?? '',
+      role: 'user'
+    })
+  }
+  
+  toDto() {
+    return { ...this.props };
   }
 }

--- a/src/routes/users/users.repository.ts
+++ b/src/routes/users/users.repository.ts
@@ -2,6 +2,7 @@ import { DatabaseError } from "./users.error.js";
 import { UpdateReformerProfileParams, UpdateUserProfileParams } from "./dto/users.req.dto.js";
 import prisma from "../../config/prisma.config.js";
 import { user, owner } from "@prisma/client";
+import { RawUserPorfile } from './users.model.js'
 
 export class UsersRepository {
   async updateUserProfile(updateUserProfileParams: UpdateUserProfileParams): Promise<user> {
@@ -55,5 +56,22 @@ export class UsersRepository {
       console.error(error);
       throw new DatabaseError('리폼러 조회 중 DB에서 오류가 발생했습니다.');
     }
+  }
+
+  async getUserProfile(userId: string): Promise<RawUserPorfile | null> {
+    const userProfile = await prisma.user.findUnique({
+      where: {
+        user_id: userId
+      },
+      select: {
+        user_id: true,
+        email: true,
+        name: true,
+        nickname: true,
+        phone: true,
+        profile_photo: true
+      }
+    })
+    return userProfile
   }
 }

--- a/src/routes/users/users.service.ts
+++ b/src/routes/users/users.service.ts
@@ -1,9 +1,32 @@
-import { CheckNicknameResponse, UpdateUserProfileResponseDto, UsersInfoResponse, UpdateReformerProfileResponseDto, UserDetailInfoResponseDto, ReformerDetailInfoResponseDto } from './dto/users.res.dto.js';
-import { UpdateReformerStatusRequest, UpdateUserProfileParams, UpdateUserProfileRequestDto, UpdateReformerProfileRequestDto, UpdateReformerProfileParams } from './dto/users.req.dto.js';
+import { 
+  CheckNicknameResponse, 
+  UpdateUserProfileResponseDto, 
+  UsersInfoResponse, 
+  UpdateReformerProfileResponseDto, 
+  UserDetailInfoResponseDto, 
+  ReformerDetailInfoResponseDto 
+} from './dto/users.res.dto.js';
+import { 
+  UpdateReformerStatusRequest, 
+  UpdateUserProfileParams, 
+  UpdateUserProfileRequestDto,
+  UpdateReformerProfileRequestDto, 
+  UpdateReformerProfileParams 
+} from './dto/users.req.dto.js';
 import { validateNickname } from '../../utils/validators.js';
-import { UsersModel } from './users.model.js';
-import { EmailDuplicateError, UnknownAuthError, AccountNotFoundError } from '../auth/auth.error.js';
-import { NicknameDuplicateError, PhoneNumberDuplicateError } from './users.error.js';
+import { 
+  UsersModel, 
+  UserProfile 
+} from './users.model.js';
+import { 
+  EmailDuplicateError,
+  UnknownAuthError, 
+  AccountNotFoundError 
+} from '../auth/auth.error.js';
+import { 
+  NicknameDuplicateError, 
+  PhoneNumberDuplicateError 
+} from './users.error.js';
 import { UsersRepository } from './users.repository.js';
 import { AuthStatus } from '../auth/auth.dto.js';
 
@@ -121,5 +144,14 @@ export class UsersService {
       return reformerDetailInfo;
     }
     throw new AccountNotFoundError('존재하지 않는 리폼러입니다.');
+  }
+
+  // 일반 유저 프로필 조회
+  async getUserProfile(userId: string): Promise<UserProfile> {
+    const userProfile = await this.usersRepository.getUserProfile(userId);
+    if (!userProfile){
+      throw new AccountNotFoundError('존재하지 않는 유저 계정입니다.')
+    }
+    return UserProfile.create(userProfile)
   }
 }


### PR DESCRIPTION
## 개요
일반 유저 프로필 정보를 불러오는 기능을 구현함

## 주요 변경 사항

- [ ] GET /users/user/me/profile 추가

## 관련 이슈/마일스톤

- Closes #109 
- Relates to #109 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [ ] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)
