### PR TITLE
Feat : Home 반환값 수정 및 마켓 카테고리 조회 API 구현

### DIFF
--- a/src/routes/home/home.controller.ts
+++ b/src/routes/home/home.controller.ts
@@ -100,6 +100,9 @@ export class HomeController extends Controller {
               thumbnail: 'https://example.com/proposal1.jpg',
               title: '커스텀 오더',
               min_price: 100000,
+              star: 4.5,
+              review_count: 12,
+              is_wished: false,
               owner_id: '990e8400-e29b-41d4-a716-446655440004',
               owner_nickname: '리포머닉네임'
             }

--- a/src/routes/home/home.model.ts
+++ b/src/routes/home/home.model.ts
@@ -43,6 +43,9 @@ export interface CustomOrder {
   thumbnail: string;
   title: string;
   min_price: number;
+  star: number;
+  review_count: number;
+  is_wished: boolean;
   owner_id: string;
   owner_nickname: string;
 }

--- a/src/routes/home/home.repository.ts
+++ b/src/routes/home/home.repository.ts
@@ -106,6 +106,27 @@ export class HomeRepository {
   }
 
   /**
+   * @returns Set<string> - 찜한 프로포절(reform_proposal) ID 목록
+   */
+  async findUserWishProposalIdsByUserId(userId: string): Promise<Set<string>> {
+    const wishList = await prisma.user_wish.findMany({
+      where: {
+        user_id: userId,
+        target_type: 'PROPOSAL'
+      },
+      select: {
+        target_id: true
+      }
+    });
+
+    return new Set(
+      wishList
+        .map((w) => w.target_id)
+        .filter((id): id is string => !!id)
+    );
+  }
+
+  /**
    * @param limit 조회할 개수 (기본값: 3)
    */
   async findRecentProposals(limit: number = 3): Promise<ReformProposalWithRelations[]> {

--- a/src/routes/home/home.service.ts
+++ b/src/routes/home/home.service.ts
@@ -240,13 +240,19 @@ export class HomeService {
   }
 
   private mapProposalToCustomOrderDto(
-    proposal: Awaited<ReturnType<typeof this.repository.findRecentProposals>>[0]
+    proposal: Awaited<ReturnType<typeof this.repository.findRecentProposals>>[0],
+    wishedProposalIds: Set<string>
   ): CustomOrderDto {
+    const avgStar = proposal.avg_star != null ? Number(proposal.avg_star) : 0;
+    const reviewCount = proposal.review_count ?? 0;
     return {
       proposal_id: proposal.reform_proposal_id,
       thumbnail: proposal.reform_proposal_photo[0]?.content || '',
       title: proposal.title || '',
       min_price: proposal.price ? Number(proposal.price) : 0,
+      star: Math.round(avgStar * 10) / 10,
+      review_count: reviewCount,
+      is_wished: wishedProposalIds.has(proposal.reform_proposal_id),
       owner_id: proposal.owner_id,
       owner_nickname: proposal.owner.nickname || ''
     };
@@ -254,8 +260,15 @@ export class HomeService {
 
   async getCustomOrders(userId?: string): Promise<CustomOrderDto[]> {
     try {
-      const proposals = await this.fetchCustomOrdersFromDb();
-      return proposals.map((proposal) => this.mapProposalToCustomOrderDto(proposal));
+      const [proposals, wishedProposalIds] = await Promise.all([
+        this.fetchCustomOrdersFromDb(),
+        userId
+          ? this.repository.findUserWishProposalIdsByUserId(userId)
+          : Promise.resolve(new Set<string>())
+      ]);
+      return proposals.map((proposal) =>
+        this.mapProposalToCustomOrderDto(proposal, wishedProposalIds)
+      );
     } catch (error) {
       if (error instanceof CustomOrdersError) {
         throw error;

--- a/src/routes/market/dto/market.res.dto.ts
+++ b/src/routes/market/dto/market.res.dto.ts
@@ -6,8 +6,15 @@ export interface CategoryItemDto {
   sortOrder: number;
 }
 
+export interface CategoryTreeItemDto {
+  categoryId: string;
+  name: string;
+  sortOrder: number;
+  children: CategoryTreeItemDto[];
+}
+
 export interface GetCategoriesResponseDto {
-  categories: CategoryItemDto[];
+  categories: CategoryTreeItemDto[];
 }
 
 export interface GetItemListResponseDto {

--- a/src/routes/market/dto/market.res.dto.ts
+++ b/src/routes/market/dto/market.res.dto.ts
@@ -1,3 +1,15 @@
+export interface CategoryItemDto {
+  categoryId: string;
+  name: string;
+  parentId: string | null;
+  depth: number;
+  sortOrder: number;
+}
+
+export interface GetCategoriesResponseDto {
+  categories: CategoryItemDto[];
+}
+
 export interface GetItemListResponseDto {
   items: Array<{
     item_id: string;

--- a/src/routes/market/market.controller.ts
+++ b/src/routes/market/market.controller.ts
@@ -22,6 +22,7 @@ import {
 } from './dto/market.req.dto.js';
 import type { Request as ExpressRequest } from 'express';
 import type {
+  GetCategoriesResponseDto,
   GetItemListResponseDto,
   GetItemDetailResponseDto,
   GetItemReviewsResponseDto,
@@ -40,6 +41,22 @@ export class MarketController extends Controller {
     this.marketService = new MarketService();
   }
 
+  /**
+   * 카테고리 목록 조회
+   * @summary 마켓 필터용 카테고리 목록을 조회합니다
+   * @returns 카테고리 목록 (categoryId, name, parentId, depth, sortOrder)
+   */
+  @Get('categories')
+  @SuccessResponse(200, '카테고리 목록 조회 성공')
+  @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  public async getCategories(): Promise<TsoaResponse<GetCategoriesResponseDto>> {
+    const result = await this.marketService.getCategories();
+    return {
+      resultType: 'SUCCESS',
+      error: null,
+      success: result
+    };
+  }
 
   /**
    * 상품 목록 조회

--- a/src/routes/market/market.repository.ts
+++ b/src/routes/market/market.repository.ts
@@ -14,6 +14,22 @@ export class MarketRepository {
   }
 
   /**
+   * 카테고리 전체 목록 조회 (sort_order, depth 기준 정렬)
+   */
+  async findCategories() {
+    return await prisma.category.findMany({
+      orderBy: [{ depth: 'asc' }, { sort_order: 'asc' }],
+      select: {
+        category_id: true,
+        name: true,
+        parent_id: true,
+        depth: true,
+        sort_order: true
+      }
+    });
+  }
+
+  /**
    * 상품 목록 조회 (필터 및 정렬 적용)
    */
   async findItemsWithFilters(

--- a/src/routes/market/market.service.ts
+++ b/src/routes/market/market.service.ts
@@ -6,6 +6,7 @@ import {
 import type { Prisma } from '@prisma/client';
 import { Prisma as PrismaClient } from '@prisma/client';
 import type {
+  GetCategoriesResponseDto,
   GetItemListResponseDto,
   GetItemDetailResponseDto,
   GetItemReviewsResponseDto,
@@ -21,6 +22,22 @@ export class MarketService {
   private static readonly DEFAULT_DELIVERY_INFO = '평균 3일 이내 배송 시작';
   private static readonly MAX_PREVIEW_PHOTOS = 7;
   private static readonly DEFAULT_REVIEW_LIMIT = 5;
+
+  /**
+   * 카테고리 목록 조회
+   */
+  async getCategories(): Promise<GetCategoriesResponseDto> {
+    const rows = await this.repository.findCategories();
+    return {
+      categories: rows.map((row) => ({
+        categoryId: row.category_id,
+        name: row.name,
+        parentId: row.parent_id,
+        depth: row.depth,
+        sortOrder: row.sort_order
+      }))
+    };
+  }
 
   /**
    * 상품 목록 조회

--- a/src/routes/market/market.service.ts
+++ b/src/routes/market/market.service.ts
@@ -6,6 +6,7 @@ import {
 import type { Prisma } from '@prisma/client';
 import { Prisma as PrismaClient } from '@prisma/client';
 import type {
+  CategoryTreeItemDto,
   GetCategoriesResponseDto,
   GetItemListResponseDto,
   GetItemDetailResponseDto,
@@ -28,14 +29,34 @@ export class MarketService {
    */
   async getCategories(): Promise<GetCategoriesResponseDto> {
     const rows = await this.repository.findCategories();
+    const flat = rows.map((row) => ({
+      categoryId: row.category_id,
+      name: row.name,
+      parentId: row.parent_id,
+      depth: row.depth,
+      sortOrder: row.sort_order
+    }));
+
+    const roots = flat.filter((c) => c.parentId === null).sort((a, b) => a.sortOrder - b.sortOrder);
+    const byParent = new Map<string | null, typeof flat>();
+    for (const c of flat) {
+      const key = c.parentId;
+      if (!byParent.has(key)) byParent.set(key, []);
+      byParent.get(key)!.push(c);
+    }
+
+    const buildTree = (parentId: string | null): CategoryTreeItemDto[] => {
+      const items = (byParent.get(parentId) ?? []).sort((a, b) => a.sortOrder - b.sortOrder);
+      return items.map((item) => ({
+        categoryId: item.categoryId,
+        name: item.name,
+        sortOrder: item.sortOrder,
+        children: buildTree(item.categoryId)
+      }));
+    };
+
     return {
-      categories: rows.map((row) => ({
-        categoryId: row.category_id,
-        name: row.name,
-        parentId: row.parent_id,
-        depth: row.depth,
-        sortOrder: row.sort_order
-      }))
+      categories: buildTree(null)
     };
   }
 


### PR DESCRIPTION
## 제목
Feat : Home 반환값 수정 및 마켓 카테고리 조회 API 구현

## 개요
home(GET) 반환 값 중 custom_orders 내 star, review_count, is_wished 추가 및 마켓 카테고리 종류 조회 API(GET) 트리  형태로 구현

## 주요 변경 사항

- [x] custom_orders 내 star, review_count, is_wished 추가 
- [x] 켓 카테고리 종류 조회 API(GET) 구현

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #107 
- Relates to #107 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
