### PR TITLE
Feat : 리폼러 회원가입 필드 타입 및 리폼러 인증 상태 변경시 문자 기능 추가

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -235,11 +235,9 @@ export class AuthController extends Controller {
   @Response<ErrorResponse>('500', '서버 내부 오류')
   @Post('signup/reformer')
   public async signupReformer(
-  @FormField() data: string,
-  @UploadedFiles('portfolios') portfolioPhotos: Express.Multer.File[]
+    @Body() requestBody: ReformerSignupRequest
   ): Promise<TsoaResponse<AuthPublicResponse>> {
-    const requestBody: ReformerSignupRequest = JSON.parse(data);
-    const result = await this.authService.signupReformer(requestBody, portfolioPhotos);
+    const result = await this.authService.signupReformer(requestBody);
     const { accessToken, refreshToken } = result;
     this.setStatus(201);
     this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; HttpOnly; Secure; Max-Age=1209600; Path=/; SameSite=none`);

--- a/src/routes/auth/auth.dto.ts
+++ b/src/routes/auth/auth.dto.ts
@@ -134,6 +134,7 @@ export interface UserCreateResponseDto {
 export interface ReformerSignupRequest extends UserSignupRequest {
   businessNumber: string;
   description: string;
+  portfolioPhotos: string[];  
 }
 
 // 리폼러 db 생성 요청 데이터 (Service -> Model)

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -172,11 +172,9 @@ export class AuthService {
   }
 
   // 리폼러 회원가입 처리
-  async signupReformer(requestBody: ReformerSignupRequest, portfolioPhotos: Express.Multer.File[])
+  async signupReformer(requestBody: ReformerSignupRequest)
   : Promise<AuthLoginResponse> {
-    await this.validateReformerSignupRequest(requestBody, portfolioPhotos);
-    const s3 = new S3();
-    const portfolioUrls = await s3.uploadManyToS3(portfolioPhotos);
+    await this.validateReformerSignupRequest(requestBody);
     return await this.processSignup(requestBody,  async (hashedPassword, cleanPhoneNumber) => {
       const { password, phoneNumber, oauthId, ...rest } = requestBody;
       const ownerDto: OwnerCreateDto = {
@@ -187,7 +185,7 @@ export class AuthService {
         role: 'reformer' as Role,
         businessNumber: this.getCleanBusinessNumber(rest.businessNumber),
         description: requestBody.description,
-        portfolioPhotos: portfolioUrls
+        portfolioPhotos: requestBody.portfolioPhotos
       };
       return await this.authModel.createOwner(ownerDto);
     });
@@ -381,11 +379,11 @@ export class AuthService {
   }
 
   // 리폼러 회원가입시 입력한 정보 유효성 검증
-  private async validateReformerSignupRequest(requestBody: ReformerSignupRequest, portfolioPhotos: Express.Multer.File[]): Promise<void> {
+  private async validateReformerSignupRequest(requestBody: ReformerSignupRequest): Promise<void> {
     await this.validateSignupRequest(requestBody, 'reformer');
     validateBusinessNumber(requestBody.businessNumber);
     validateDescription(requestBody.description);
-    validatePortfolioPhotos(portfolioPhotos);
+    validatePortfolioPhotos(requestBody.portfolioPhotos);
   }
 
   // 전화번호 숫자만 추출

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -8,7 +8,6 @@ import dotenv from 'dotenv';
 import * as bcrypt from 'bcrypt';
 import { runInTransaction } from '../../config/prisma.config.js';
 import { AuthModel } from './auth.model.js';
-import { S3 } from '../../config/s3.js';
 import { UsersModel } from '../users/users.model.js';
 import { UsersInfoResponse } from '../users/dto/users.res.dto.js';
 import { REDIS_KEYS } from '../../config/redis.js';
@@ -49,7 +48,7 @@ export class AuthService {
       attempts: 0,
       generatedAt: Date.now()
     });
-    const textMessage = `[니폼내폼] 본인 확인 인증번호 [${authCode}]입니다.`;
+    const textMessage = `[내폼리폼] 본인 확인 인증번호 [${authCode}]입니다.`;
     
     // Redis에 인증 코드 저장
     try {
@@ -71,7 +70,7 @@ export class AuthService {
       //SMS 전송 실패 시 Redis에서 인증 코드 삭제
       await redisClient.del(authKey);
       console.log(`SMS 전송 실패로 ${cleanPhoneNumber} 번호로 ${authCode} 인증 코드를 Redis에서 삭제했습니다.`);
-      throw new SmsProviderError(`SOLAPI API 요청 실패 : ${error.message}`);
+      throw new SmsProviderError(`SMS API 요청 실패 : ${error.message}`);
     }  
   }
 

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -55,7 +55,7 @@ export class UsersController extends Controller {
   }
 
   /**
-   * @summary 리폼러 인증 상태를 업데이트합니다.
+   * @summary 리폼러 인증 상태를 업데이트합니다. 상태가 변경되면 리폼러에게 문자로 변경 사항을 안내합니다.
    * @param reformerId 리폼러 ID
    * @param requestBody 목표 상태 (PENDING, APPROVED, REJECTED)
    * @returns 리폼러 상태 업데이트 결과

--- a/src/routes/users/users.error.ts
+++ b/src/routes/users/users.error.ts
@@ -24,4 +24,3 @@ export class InvalidBioLengthError extends BasicError {
     super(400, 'Users_103', '자기 소개의 길이가 적절하지 않습니다.', description);
   }
 }
-

--- a/src/routes/users/users.service.ts
+++ b/src/routes/users/users.service.ts
@@ -6,6 +6,7 @@ import {
   UserDetailInfoResponseDto, 
   ReformerDetailInfoResponseDto 
 } from './dto/users.res.dto.js';
+import { SolapiMessageService} from 'solapi';
 import { 
   UpdateReformerStatusRequest, 
   UpdateUserProfileParams, 
@@ -21,7 +22,8 @@ import {
 import { 
   EmailDuplicateError,
   UnknownAuthError, 
-  AccountNotFoundError 
+  AccountNotFoundError, 
+  SmsProviderError
 } from '../auth/auth.error.js';
 import { 
   NicknameDuplicateError, 
@@ -29,6 +31,11 @@ import {
 } from './users.error.js';
 import { UsersRepository } from './users.repository.js';
 import { AuthStatus } from '../auth/auth.dto.js';
+
+const messageService = new SolapiMessageService(
+  process.env.SOLAPI_API_KEY || '',
+  process.env.SOLAPI_API_SECRET || ''
+);
 
 export class UsersService {
 
@@ -41,7 +48,18 @@ export class UsersService {
 
   // 리폼러 상태 업데이트
   async updateReformerStatus(reformerId: string, requestBody: UpdateReformerStatusRequest): Promise<UsersInfoResponse> {
+    const reformer = await this.usersRepository.findReformerbyReformerId(reformerId);
+    if (!reformer) {
+      throw new AccountNotFoundError('리폼러의 계정이 존재하지 않습니다.')
+    }
     const result = await this.usersModel.updateReformerStatus(reformerId, requestBody);
+    
+    
+    if (result.auth_status && reformer.status !== result.auth_status) {
+      this.sendNotificationSms(reformer.phone, result.auth_status).catch(err => {
+        console.error(`[SMS 전송 실패] ID: ${reformerId}, Error: ${err.message}`)
+      })
+    }
     return result as UsersInfoResponse;
   }
 
@@ -153,5 +171,28 @@ export class UsersService {
       throw new AccountNotFoundError('존재하지 않는 유저 계정입니다.')
     }
     return UserProfile.create(userProfile)
+  }
+
+  private async sendNotificationSms(phone: string | null, status: string) {
+    if (!phone) return;
+
+    const statusMap: Record<string, string> = {
+      'APPROVED': '승인',
+      'REJECTED': '승인 거부',
+      'PENDING': '대기 상태로 변경'
+    };
+
+    const resultStatus = statusMap[status] || '처리';
+    const textMessage = `[내폼리폼] 프로필 검토 결과 ${resultStatus}되었음을 알려드립니다.`;
+
+    try {
+      await messageService.send({
+        to: phone,
+        from: process.env.SOLAPI_PHONE_NUMBER!,
+        text: textMessage
+      });
+    } catch (error: any) {
+      throw new SmsProviderError(`SMS API 요청 실패 : ${error.message}`);
+    }
   }
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -87,9 +87,9 @@ export const validateDescription = (description: string): void => {
   }
 };
 
-export const validatePortfolioPhotos = (portfolioPhotos: Express.Multer.File[]): void => {
-  if (portfolioPhotos.length === 0 || portfolioPhotos.length > 9){
-    throw new InvalidPhotoNumberError('입력한 사진의 개수가 올바르지 않습니다. 1장 이상 9장 이하로 업로드해주세요.');
+export const validatePortfolioPhotos = (portfolioPhotos: string[]): void => {
+  if (portfolioPhotos.length === 0 || portfolioPhotos.length > 8){
+    throw new InvalidPhotoNumberError('입력한 사진의 개수가 올바르지 않습니다. 1장 이상 8장 이하로 업로드해주세요.');
   }
 };
 


### PR DESCRIPTION
## 개요

리폼러 회원가입 필드를 기존의 form-data에서 json입력으로 변경하고, 리폼러의 인증 상태가 변경되면 문자를 전송하는 기능을 추가합니다.

## 주요 변경 사항

POST 'users/signup/reformer' 입력 필드 타입 변경 (form-data -> string)
PATCH 'users/reformer/{reformerId}/status' 문자 전송 로직 추가

## 관련 이슈/마일스톤

- Closes #112 
- Relates to #112

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)
