### PR TITLE
fix: 메세지 목록 형식 수정

### DIFF
--- a/src/routes/chat/chat.controller.ts
+++ b/src/routes/chat/chat.controller.ts
@@ -92,7 +92,7 @@ export class ChatController extends Controller {
           image: "https://s3.example.com/thumb.jpg",
           title: "리폼마스터",
           roomType: "FEED",
-          messageType: "TEXT",
+          messageType: "text",
           type: "INQUIRY",
           lastMessage: "안녕하세요, 문의드립니다.",
           lastMessageAt: new Date(),

--- a/src/routes/chat/chat.dto.ts
+++ b/src/routes/chat/chat.dto.ts
@@ -1,5 +1,5 @@
 import { UUID } from '../../@types/common.js';
-import { ChatRoomFilter } from './chat.model.js';
+import { ChatRoomFilter, MessageType } from './chat.model.js';
 
 /**
  * @pattern ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
@@ -145,7 +145,7 @@ export interface ChatRoomPreviewDTO {
      * 마지막 메시지 타입
      * @example "TEXT"
      */
-    messageType: 'TEXT' | 'IMAGE' | 'OTHER';
+    messageType: MessageType;
     /**
      * 채팅방 분류
      * - INQUIRY: 문의 채팅

--- a/src/routes/chat/chat.repository.ts
+++ b/src/routes/chat/chat.repository.ts
@@ -223,9 +223,9 @@ export class ChatRepository {
       image: isFeed ? opponent?.profile_photo || '' : payload?.image || '',
       title: isFeed ? opponent?.nickname || '' : payload?.title || '주문 상세',
       roomType: row.type,
-      messageType: (lastMessage?.message_type as any) || 'TEXT',
+      messageType: (lastMessage?.message_type as any) || 'undefined',
       type: isFeed ? 'INQUIRY' : 'ORDER',
-      lastMessage: lastMessage?.text_content || '',
+      lastMessage: lastMessage?.text_content || null,
       lastMessageAt: lastMessage?.created_at || row.created_at,
       unreadCount: isOwner ? row.owner_unread_count : row.requester_unread_count
     };


### PR DESCRIPTION
## 제목

<!-- 예: feat: 로그인 기능 구현 (#1) -->

## 개요

프론트에서 텍스트 외 마지막 메세지 표시를 위한 타입 지정

<!-- PR 목적과 변경 이유를 간단히 설명해주세요. -->

## 주요 변경 사항

- [ ] 채팅방 목록에서 마지막 메세지 표시 부분 타입 수정
- [ ]

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #
- Relates to #

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [ ] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [ ] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [ ] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [ ] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
