### PR TITLE
Feat : 리폼러 프로필 닉네임 조회 추가 및 3개월 평균 별점 추가

### DIFF
--- a/src/routes/market/dto/market.res.dto.ts
+++ b/src/routes/market/dto/market.res.dto.ts
@@ -56,6 +56,7 @@ export interface GetItemDetailResponseDto {
     profile_image: string | null;
     nickname: string | null;
     star: number;
+    star_recent_3m: number;
     order_count: number;
   };
   is_wished: boolean;

--- a/src/routes/market/market.controller.ts
+++ b/src/routes/market/market.controller.ts
@@ -219,6 +219,7 @@ export class MarketController extends Controller {
         profile_image: 'https://example.com/profile.jpg',
         nickname: '리포머닉네임',
         star: 4.8,
+        star_recent_3m: 4.5,
         order_count: 500
       },
       is_wished: false,

--- a/src/routes/market/market.repository.ts
+++ b/src/routes/market/market.repository.ts
@@ -220,6 +220,22 @@ export class MarketRepository {
   }
 
   /**
+   * 해당 오너(리폼러)의 최근 3개월 리뷰 평균 별점
+   */
+  async findAvgStarRecent3MonthsByOwnerId(ownerId: string): Promise<number | null> {
+    const threeMonthsAgo = new Date();
+    threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+    const result = await prisma.review.aggregate({
+      where: {
+        owner_id: ownerId,
+        created_at: { gte: threeMonthsAgo }
+      },
+      _avg: { star: true }
+    });
+    return result._avg.star != null ? Number(result._avg.star) : null;
+  }
+
+  /**
    * 상품의 리뷰 목록 조회 (제한된 개수)
    */
   async findReviewsForItemPreview(itemId: string, limit: number): Promise<ReviewWithPhotos[]> {

--- a/src/routes/market/market.service.ts
+++ b/src/routes/market/market.service.ts
@@ -148,7 +148,10 @@ export class MarketService {
       const isWished = await this.checkItemWished(userId, itemId);
       const images = this.extractItemImages(item);
       const optionGroups = this.transformOptionGroups(item);
-      const reviewData = await this.getReviewDataForItem(itemId);
+      const [reviewData, starRecent3m] = await Promise.all([
+        this.getReviewDataForItem(itemId),
+        this.repository.findAvgStarRecent3MonthsByOwnerId(item.owner.owner_id)
+      ]);
       const itemThumbnail = await this.getItemThumbnail(itemId);
       const reviews = await this.transformReviews(reviewData.allReviews, itemThumbnail);
 
@@ -165,6 +168,7 @@ export class MarketService {
           profile_image: item.owner.profile_photo,
           nickname: item.owner.nickname,
           star: item.owner.avg_star ? Number(item.owner.avg_star) : 0,
+          star_recent_3m: starRecent3m ?? 0,
           order_count: item.owner.trade_count || 0
         },
         is_wished: isWished,

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -36,9 +36,11 @@ export interface SaleDetailResponseDto extends SaleResponseDto {
 // --- 5 GET 응답 타입 (profile/{id}, feed, item, proposal, review) ---
 
 export interface ProfileInfoResponse {
+  ownerId: string;
   profilePhoto: string | null;
   nickname: string | null;
   avgStar: number | null;
+  avgStarRecent3m: number;
   reviewCount: number | null;
   totalSaleCount: number;
   keywords: string[];

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -10,7 +10,8 @@ import {
   Body,
   Query,
   Security,
-  Request
+  Request,
+  Example
 } from 'tsoa';
 import type { Request as ExpressRequest } from 'express';
 import { ProfileService } from './profile.service.js';
@@ -388,9 +389,9 @@ export class ProfileController extends Controller {
 
   /**
    * 프로필 기본 정보 조회
-   * @summary owner ID로 프로필 정보(닉네임, 평점, 리뷰 수 등)를 조회합니다
-   * @param id owner UUID
-   * @returns 프로필 정보
+   * @summary 리폼러 프로필 정보(닉네임, 평점, 리뷰 수 등)를 조회합니다. owner UUID 또는 닉네임으로 조회할 수 있습니다.
+   * @param id owner UUID 또는 리폼러 닉네임
+   * @returns 프로필 정보 (ownerId, avgStarRecent3m 포함)
    */
   @Get('{id}')
   @SuccessResponse(200, '프로필 정보 조회 성공')
@@ -408,6 +409,21 @@ export class ProfileController extends Controller {
     }
   )
   @Response<ErrorResponse>(500, '서버 에러', commonError.serverError)
+  @Example<TsoaResponse<ProfileInfoResponse>>({
+    resultType: 'SUCCESS',
+    error: null,
+    success: {
+      ownerId: '880e8400-e29b-41d4-a716-446655440000',
+      profilePhoto: 'https://example.com/profile.jpg',
+      nickname: '리폼러닉네임',
+      avgStar: 4.5,
+      avgStarRecent3m: 4.2,
+      reviewCount: 120,
+      totalSaleCount: 45,
+      keywords: ['리폼', '수선'],
+      bio: '프로필 소개글입니다.'
+    }
+  })
   public async getProfileInfo(
     @Path() id: string
   ): Promise<TsoaResponse<ProfileInfoResponse>> {
@@ -455,8 +471,8 @@ export class ProfileController extends Controller {
 
   /**
    * 프로필 판매 상품 목록 조회 (cursor 기반)
-   * @summary owner의 판매 상품 목록을 조회합니다 (로그인 시 찜 여부 포함)
-   * @param id owner UUID
+   * @summary owner의 판매 상품 목록을 조회합니다 (로그인 시 찜 여부 포함). id는 owner UUID 또는 닉네임입니다.
+   * @param id owner UUID 또는 리폼러 닉네임
    * @param cursor 페이지네이션 커서 (선택)
    * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
    * @returns 판매 상품 목록
@@ -496,8 +512,8 @@ export class ProfileController extends Controller {
 
   /**
    * 프로필 주문제작 목록 조회 (cursor 기반)
-   * @summary owner의 주문제작 상품 목록을 조회합니다 (로그인 시 찜 여부 포함)
-   * @param id owner UUID
+   * @summary owner의 주문제작 상품 목록을 조회합니다 (로그인 시 찜 여부 포함). id는 owner UUID 또는 닉네임입니다.
+   * @param id owner UUID 또는 리폼러 닉네임
    * @param cursor 페이지네이션 커서 (선택)
    * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
    * @returns 주문제작 목록
@@ -537,8 +553,8 @@ export class ProfileController extends Controller {
 
   /**
    * 프로필 리뷰 목록 조회 (cursor 기반)
-   * @summary owner에 대한 리뷰 목록을 조회합니다 (공개)
-   * @param id owner UUID
+   * @summary owner에 대한 리뷰 목록을 조회합니다 (공개). id는 owner UUID 또는 닉네임입니다.
+   * @param id owner UUID 또는 리폼러 닉네임
    * @param cursor 페이지네이션 커서 (선택)
    * @param limit 한 번에 조회할 개수 (기본 20, 최대 50)
    * @returns 리뷰 목록

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -399,6 +399,7 @@ export class ProfileRepository {
     return await this.prisma.owner.findUnique({
       where: { owner_id: ownerId },
       select: {
+        owner_id: true,
         profile_photo: true,
         nickname: true,
         avg_star: true,
@@ -407,6 +408,34 @@ export class ProfileRepository {
         bio: true
       }
     });
+  }
+
+  async findOwnerByNickname(nickname: string) {
+    return await this.prisma.owner.findUnique({
+      where: { nickname },
+      select: {
+        owner_id: true,
+        profile_photo: true,
+        nickname: true,
+        avg_star: true,
+        review_count: true,
+        keywords: true,
+        bio: true
+      }
+    });
+  }
+
+  async findAvgStarRecent3MonthsByOwnerId(ownerId: string): Promise<number | null> {
+    const threeMonthsAgo = new Date();
+    threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+    const result = await this.prisma.review.aggregate({
+      where: {
+        owner_id: ownerId,
+        created_at: { gte: threeMonthsAgo }
+      },
+      _avg: { star: true }
+    });
+    return result._avg.star != null ? Number(result._avg.star) : null;
   }
 
   async countSaleByOwnerId(ownerId: string): Promise<number> {

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -159,27 +159,41 @@ export class ProfileService {
     return SaleDetail.create(order, option, title);
   }
 
-  async getProfileInfo(id: string): Promise<ProfileInfoResponse> {
-    const owner = await this.profileRepository.findOwnerById(id);
-    if (!owner) {
-      throw new OwnerNotFound(id);
-    }
+  private async resolveOwner(idOrNickname: string) {
+    const trimmed = idOrNickname.trim();
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed);
+    const owner = isUuid
+      ? await this.profileRepository.findOwnerById(trimmed)
+      : await this.profileRepository.findOwnerByNickname(trimmed);
+    if (!owner) throw new OwnerNotFound(idOrNickname);
+    return owner;
+  }
+
+  async getProfileInfo(idOrNickname: string): Promise<ProfileInfoResponse> {
+    const owner = await this.resolveOwner(idOrNickname);
+    const ownerId = owner.owner_id;
 
     let avgStar = owner.avg_star ? Number(owner.avg_star) : null;
     let reviewCount = owner.review_count;
 
     if (avgStar === null || reviewCount === null) {
-      const stats = await this.profileRepository.findReviewStatsByOwnerId(id);
+      const stats = await this.profileRepository.findReviewStatsByOwnerId(ownerId);
       avgStar = stats._avg.star !== null ? Number(stats._avg.star) : null;
       reviewCount = stats._count.review_id ?? 0;
     }
 
-    const totalSaleCount = await this.profileRepository.countSaleByOwnerId(id);
+    const [totalSaleCount, avgStarRecent3mRaw] = await Promise.all([
+      this.profileRepository.countSaleByOwnerId(ownerId),
+      this.profileRepository.findAvgStarRecent3MonthsByOwnerId(ownerId)
+    ]);
+    const avgStarRecent3m = avgStarRecent3mRaw ?? 0;
 
     return {
+      ownerId: owner.owner_id,
       profilePhoto: owner.profile_photo,
       nickname: owner.nickname,
       avgStar,
+      avgStarRecent3m,
       reviewCount,
       totalSaleCount,
       keywords: owner.keywords ?? [],
@@ -192,13 +206,11 @@ export class ProfileService {
     cursor: string | undefined,
     limit: number
   ): Promise<FeedListResponse> {
-    const owner = await this.profileRepository.findOwnerById(id);
-    if (!owner) {
-      throw new OwnerNotFound(id);
-    }
+    const owner = await this.resolveOwner(id);
+    const ownerId = owner.owner_id;
 
     const take = Math.min(limit, 50);
-    const feeds = await this.profileRepository.findFeedsByOwnerId(id, cursor, take);
+    const feeds = await this.profileRepository.findFeedsByOwnerId(ownerId, cursor, take);
     const hasNext = feeds.length > take;
     const actualFeeds = hasNext ? feeds.slice(0, take) : feeds;
 
@@ -232,13 +244,10 @@ export class ProfileService {
     limit: number,
     userId: string | undefined
   ): Promise<MarketListResponse> {
-    const owner = await this.profileRepository.findOwnerById(id);
-    if (!owner) {
-      throw new OwnerNotFound(id);
-    }
+    const ownerId = await this.resolveOwnerId(id);
 
     const take = Math.min(limit, 50);
-    const items = await this.profileRepository.findItemsByOwnerId(id, cursor, take);
+    const items = await this.profileRepository.findItemsByOwnerId(ownerId, cursor, take);
     const hasNext = items.length > take;
     const actualItems = hasNext ? items.slice(0, take) : items;
 
@@ -290,14 +299,12 @@ export class ProfileService {
     limit: number,
     userId: string | undefined
   ): Promise<ProposalListResponse> {
-    const owner = await this.profileRepository.findOwnerById(id);
-    if (!owner) {
-      throw new OwnerNotFound(id);
-    }
+    const owner = await this.resolveOwner(id);
+    const ownerId = owner.owner_id;
 
     const take = Math.min(limit, 50);
     const proposals = await this.profileRepository.findProposalsByOwnerId(
-      id,
+      ownerId,
       cursor,
       take
     );
@@ -353,13 +360,11 @@ export class ProfileService {
     cursor: string | undefined,
     limit: number
   ): Promise<ReviewListResponse> {
-    const owner = await this.profileRepository.findOwnerById(id);
-    if (!owner) {
-      throw new OwnerNotFound(id);
-    }
+    const owner = await this.resolveOwner(id);
+    const ownerId = owner.owner_id;
 
     const take = Math.min(limit, 50);
-    const reviews = await this.profileRepository.findReviewsByOwnerId(id, cursor, take);
+    const reviews = await this.profileRepository.findReviewsByOwnerId(ownerId, cursor, take);
     const hasNext = reviews.length > take;
     const actualReviews = hasNext ? reviews.slice(0, take) : reviews;
 


### PR DESCRIPTION
## 제목

Feat : 리폼러 프로필 닉네임 조회 추가 및 3개월 평균 별점 추가

## 개요

리폼러 프로필 닉네임 조회 추가 및 3개월 평균 별점 추가

## 주요 변경 사항

- [x] 마켓 상세보기 API 내 3개월 평균 별점 추가
- [x] profile 조회 API 내 닉네임 조회 추가

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #118 
- Relates to #118

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
