### PR TITLE
Feat : 카카오 로그인 리다이렉트 설정 반영

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,8 +17,8 @@ app.use(morgan('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
-const allowedOrigins = process.env.FRONTEND_URL
-  ? process.env.FRONTEND_URL.split(',').map(origin => origin.trim())
+const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
+  ? process.env.CORS_ALLOWED_ORIGINS.split(',').map(origin => origin.trim())
   : [];
 app.use(cors({
   origin: allowedOrigins,

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -89,11 +89,20 @@ export class AuthController extends Controller {
   @Response<ErrorResponse>('500', '서버 내부 오류')
   @SuccessResponse(302, '카카오 로그인 페이지로 리다이렉트')  
   @Get('kakao')
-  public async loginWithKakao(@Request() request: express.Request, @Query() mode: Role): Promise<void> {
+  public async loginWithKakao(
+    @Request() request: express.Request, 
+    @Query() mode: Role,
+    @Query() redirectUrl?: string
+  ): Promise<void> {
     const res = (request as any).res as express.Response;
     const next = (request as any).next as express.NextFunction;
+    const stateData = {
+      mode,
+      redirectUrl
+    }
+    const state = JSON.stringify(stateData);
     // 카카오 로그인 페이지로 리다이렉트, state에 mode 값을 전달하여 로그인 모드 구분
-    passport.authenticate('kakao', { session: false, state: mode })(request, res, next);
+    passport.authenticate('kakao', { session: false, state: state})(request, res, next);
   }
 
   /**
@@ -115,32 +124,36 @@ export class AuthController extends Controller {
       if (result.status == 'login'){
         res.cookie('refreshToken', result.refreshToken, {
           httpOnly: true, 
-          secure: process.env.NODE_ENV === 'production', 
+          secure: true, 
           maxAge: 60 * 60 * 24 * 14 * 1000, 
           path: '/', 
           sameSite: 'none'
         });
         res.cookie('accessToken', result.accessToken, {
           httpOnly: false, 
-          secure: process.env.NODE_ENV === 'production',
+          secure: true,
           maxAge: 5 * 60 * 1000, 
           path: '/', 
           sameSite: 'none'
         });
-        return res.redirect(process.env.FRONTEND_URL_LOGIN!);
+        const redirectUrl = (user.redirectUrl) 
+          ? `${process.env.FRONTENT_BASE_URL}${user.redirectUrl}`
+          : process.env.FRONTEND_BASE_URL
+        return res.redirect(redirectUrl!);
       }
 
       if (result.status == 'signup'){
-        const { role, kakaoId, email } = result.user;
-        // 회원가입 페이지로 리다이렉트, role, kakaoId, email 정보를 전달
-        res.cookie('signupInfo', JSON.stringify({ role, kakaoId, email }), {
+        const { role, kakaoId, email, redirectUrl } = result.user;
+        // 회원가입 페이지로 리다이렉트, role, kakaoId, email, redirectUrl 정보를 전달
+        res.cookie('signupInfo', JSON.stringify({ role, kakaoId, email, redirectUrl }), {
           httpOnly: false, 
-          secure: process.env.NODE_ENV === 'production',
+          secure: true,
           maxAge: 5 * 60 * 1000, 
           path: '/', 
           sameSite: 'none'
         });
-        return res.redirect(process.env.FRONTEND_URL_SIGNUP!);
+        const signupUrl = `${process.env.FRONTEND_BASE_URL}/kakao/signup`
+        return res.redirect(signupUrl);
       }
     } catch (error) {
       throw new KakaoAuthError('카카오 로그인 처리 중 오류가 발생했습니다.');

--- a/src/routes/auth/auth.dto.ts
+++ b/src/routes/auth/auth.dto.ts
@@ -49,6 +49,7 @@ export interface KakaoSignupResponse {
     kakaoId: string;
     email: string;
     role: string;
+    redirectUrl?: string;
   };
 }
 
@@ -81,6 +82,7 @@ export interface PassportUserInfo {
   email?: string;
   id?: string;
   auth_status?: AuthStatus;
+  redirectUrl?: string;
 }
 
 // 로그인 응답 데이터 (Service -> Controller)

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -123,7 +123,8 @@ export class AuthService {
         user: {
           kakaoId: user.kakaoId,
           email: user.email,
-          role: user.role        
+          role: user.role,
+          redirectUrl: user.redirectUrl
         }
       } as KakaoSignupResponse;
     }

--- a/src/routes/auth/passport.ts
+++ b/src/routes/auth/passport.ts
@@ -15,10 +15,20 @@ passport.use(new KakaoStrategy({
   passReqToCallback: true
 }, async (req: express.Request, accessToken: string, refreshToken: string, profile: any, done: any) => {
   // usersModel 인스턴스 생성 (DB 조회 시 사용)
-  
+  const state = req.query.state as string;
+  let mode: Role;
+  let redirectUrl: string | undefined;
+
   try {
-    const state = req.query.state as string;
-    const mode: Role = state as Role;
+    // 1. JSON 파싱 시도
+    const parsedState = JSON.parse(state);
+    mode = parsedState.mode;
+    redirectUrl = parsedState.redirectUrl;
+  } catch (e) {
+    mode = state as Role;
+  }
+
+  try {
     const role: account_role = mode === 'reformer' ? 'OWNER' : 'USER';
     const id = String(profile.id);
     const email = profile._json.kakao_account?.email || '';
@@ -31,7 +41,8 @@ passport.use(new KakaoStrategy({
         status: 'signup',
         kakaoId: id,
         email: email,
-        role: mode
+        role: mode,
+        redirectUrl: redirectUrl
       };
       return done(null, signupInfo);
     }
@@ -41,18 +52,18 @@ passport.use(new KakaoStrategy({
     const targetId = role === 'OWNER' ? socialUser.owner_id : socialUser.user_id;
     const tableName = role === 'OWNER' ? 'owner' : 'user';
 
-    if(!targetId) {
+    if (!targetId) {
       return done(new UnknownAuthError('DB의 social_account 테이블에서 사용자의 owner_id 또는 user_id를 찾을 수 없습니다.'));
     }
 
-    const accountInfo = role === 'OWNER' 
-      ? await usersModel.findReformerById(targetId) 
+    const accountInfo = role === 'OWNER'
+      ? await usersModel.findReformerById(targetId)
       : await usersModel.findUserById(targetId);
 
     if (!accountInfo) {
       return done(new UnknownAuthError(`DB의 ${tableName} 테이블에서 ${targetId}와 일치하는 사용자를 찾을 수 없습니다.`));
     }
-    return done(null, {...accountInfo, status: 'login'});
+    return done(null, { ...accountInfo, status: 'login', redirectUrl: redirectUrl });
 
   } catch (error) {
     return done(error);


### PR DESCRIPTION
## 개요

리다이렉트가 필요한 카카오 로그인의 세부 내용을 설정함

## 주요 변경 사항

- [ ] 카카오 로그인 시 리다이렉트 되는 경로를 설정함
- [ ] 회원가입의 경우 BaseURL/kakao/signup 으로 이동함
- [ ] 기존 리다이렉트 URL과 혼용되었던 CORS 변수를 분리함

## 관련 이슈/마일스톤

- Closes #128 
- Relates to #128

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)
