### PR TITLE
Feat : 리폼러 포트폴리오 불러오기 및 사업자 번호 입력 형식 변경

### DIFF
--- a/src/routes/auth/auth.dto.ts
+++ b/src/routes/auth/auth.dto.ts
@@ -134,14 +134,14 @@ export interface UserCreateResponseDto {
 
 // 리폼러 회원가입 요청 데이터 (Controller -> Service)
 export interface ReformerSignupRequest extends UserSignupRequest {
-  businessNumber: string;
+  businessNumber?: string;
   description: string;
   portfolioPhotos: string[];  
 }
 
 // 리폼러 db 생성 요청 데이터 (Service -> Model)
 export interface OwnerCreateDto extends UserCreateDto {
-  businessNumber: string;
+  businessNumber?: string;
   description: string;
   portfolioPhotos: string[];
 }

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -183,9 +183,9 @@ export class AuthService {
         hashedPassword: hashedPassword,
         phoneNumber: cleanPhoneNumber,
         role: 'reformer' as Role,
-        businessNumber: this.getCleanBusinessNumber(rest.businessNumber),
-        description: requestBody.description,
-        portfolioPhotos: requestBody.portfolioPhotos
+        businessNumber: rest.businessNumber,
+        description: rest.description,
+        portfolioPhotos: rest.portfolioPhotos
       };
       return await this.authModel.createOwner(ownerDto);
     });
@@ -381,7 +381,9 @@ export class AuthService {
   // 리폼러 회원가입시 입력한 정보 유효성 검증
   private async validateReformerSignupRequest(requestBody: ReformerSignupRequest): Promise<void> {
     await this.validateSignupRequest(requestBody, 'reformer');
-    validateBusinessNumber(requestBody.businessNumber);
+    if (requestBody.businessNumber){
+      validateBusinessNumber(requestBody.businessNumber);
+    }    
     validateDescription(requestBody.description);
     validatePortfolioPhotos(requestBody.portfolioPhotos);
   }
@@ -389,11 +391,6 @@ export class AuthService {
   // 전화번호 숫자만 추출
   private getCleanPhoneNumber(phoneNumber: string): string {
     return phoneNumber.replace(/[^0-9]/g, '');
-  }
-
-  // 사업자번호 숫자만 추출
-  private getCleanBusinessNumber(businessNumber: string): string {
-    return businessNumber.replace(/[^0-9]/g, '');
   }
 
   // 휴대폰 인증 확인

--- a/src/routes/users/dto/users.res.dto.ts
+++ b/src/routes/users/dto/users.res.dto.ts
@@ -1,5 +1,6 @@
 import { AuthStatus, Role } from '../../auth/auth.dto.js';
 import { owner, user } from '@prisma/client';
+import { rawReformerPortfolio } from '../users.model.js';
 
 // 닉네임 중복 검사 응답 데이터
 export interface CheckNicknameResponse {
@@ -116,4 +117,50 @@ export interface UserProfileResponseDto{
   phone: string,
   profilePhoto: string,
   role: Role
+}
+
+export class ReformerPortfolioDto {
+  owner_id: string;
+  name: string | null;
+  nickname: string | null;
+  email: string | null;
+  phone: string | null;
+  introduction: string | null;
+  photos: string[] | null;
+  business_number: string | null;
+
+  constructor(data: {
+    owner_id: string;
+    name: string | null;
+    nickname: string | null;
+    email: string | null;
+    phone: string | null;
+    portfolio: string | null;
+    photos: string[] | null;
+    business_number: string | null;
+  }) {
+    this.owner_id = data.owner_id;
+    this.name = data.name;
+    this.nickname = data.nickname;
+    this.email = data.email;
+    this.phone = data.phone;
+    this.introduction = data.portfolio;
+    this.photos = data.photos;
+    this.business_number = data.business_number;
+  }
+
+  static fromRaw(raw: rawReformerPortfolio): ReformerPortfolioDto {
+    const auth = raw.reformer_auth?.[0];
+
+    return new ReformerPortfolioDto({
+      owner_id: raw.owner_id,
+      name: raw.name,
+      nickname: raw.nickname,
+      email: raw.email,
+      phone: raw.phone,
+      portfolio: auth?.portfolio ?? null,
+      photos: auth?.photo ?? [],
+      business_number: auth?.business_number ?? null,
+    });
+  }
 }

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -17,10 +17,15 @@ import {
 import { ErrorResponse, ResponseHandler, TsoaResponse } from '../../config/tsoaResponse.js';
 import { CheckNicknameResponse, UpdateReformerProfileResponseDto, UserProfileResponseDto, UsersInfoResponse } from './dto/users.res.dto.js';
 import { UpdateReformerStatusRequest, UpdateUserProfileRequestDto, UpdateReformerProfileRequestDto } from './dto/users.req.dto.js';
-import { UpdateUserProfileResponseDto, UserDetailInfoResponseDto, ReformerDetailInfoResponseDto } from './dto/users.res.dto.js';
+import { 
+  UpdateUserProfileResponseDto, 
+  UserDetailInfoResponseDto, 
+  ReformerDetailInfoResponseDto,
+  ReformerPortfolioDto } from './dto/users.res.dto.js';
 import { UsersService } from './users.service.js';
 import { UnauthorizedError } from '../auth/auth.error.js';
 import { Request as ExRequest } from 'express';
+import { reformer_status_enum } from '@prisma/client';
 
 @Route('users')
 @Tags('Users')
@@ -215,5 +220,21 @@ export class UsersController extends Controller {
     const userProfile =  await this.usersService.getUserProfile(userId);
     const userProfileDto = userProfile.toDto();
     return new ResponseHandler<UserProfileResponseDto>(userProfileDto);
+  }
+
+  /**
+   * 인증 상태 별 리폼러 가입 시 입력 정보 불러오기
+   * @summary 인증 상태 별로 리폼러의 포트폴리오 정보를 불러옵니다.
+   * @returns 리폼러 회원 정보 및 회원가입 시 입력 내용
+   */
+  @SuccessResponse(200, '리폼러 포트폴리오 정보 조회 성공')
+  @Response<ErrorResponse>('500', '서버 오류')
+  @Get('reformers')
+  public async getReformersPortfolio(
+    @Query() status: reformer_status_enum,
+  )
+  : Promise<TsoaResponse<ReformerPortfolioDto[]>> {
+    const reformerPortfolios = await this.usersService.getReformerPortfolios(status);
+    return new ResponseHandler<ReformerPortfolioDto[]>(reformerPortfolios)
   }
 }

--- a/src/routes/users/users.model.ts
+++ b/src/routes/users/users.model.ts
@@ -3,6 +3,7 @@ import { UpdateUserProfileResponseDto, UsersInfoResponse, UserProfileResponseDto
 import { UpdateReformerStatusRequest } from './dto/users.req.dto.js';
 import { account_role, owner, provider_type, social_account, user } from '@prisma/client';
 import { Prisma } from '@prisma/client';
+import { UUID } from '../../@types/common.js';
 export class UsersModel {
   private prisma;
 
@@ -228,3 +229,22 @@ export class UserProfile {
     return { ...this.props };
   }
 }
+
+export type rawReformerPortfolio = Prisma.ownerGetPayload<{
+  select: {
+    owner_id: true,
+    status: true,
+    email: true,
+    name: true,
+    nickname: true,
+    phone: true,
+    reformer_auth: {
+      select: {
+        portfolio: true,
+        photo: true,
+        business_number: true
+      }
+    }
+  }  
+}>
+

--- a/src/routes/users/users.repository.ts
+++ b/src/routes/users/users.repository.ts
@@ -2,7 +2,8 @@ import { DatabaseError } from "./users.error.js";
 import { UpdateReformerProfileParams, UpdateUserProfileParams } from "./dto/users.req.dto.js";
 import prisma from "../../config/prisma.config.js";
 import { user, owner } from "@prisma/client";
-import { RawUserPorfile } from './users.model.js'
+import { RawUserPorfile, rawReformerPortfolio } from './users.model.js';
+import { reformer_status_enum } from '@prisma/client';
 
 export class UsersRepository {
   async updateUserProfile(updateUserProfileParams: UpdateUserProfileParams): Promise<user> {
@@ -73,5 +74,28 @@ export class UsersRepository {
       }
     })
     return userProfile
+  }
+
+  async getReformerPortfolios(status: reformer_status_enum): Promise<rawReformerPortfolio[]> {
+    return await prisma.owner.findMany({
+      where: {
+        status: status
+      },
+      select: {
+        owner_id: true,
+        status: true,
+        email: true,
+        name: true,
+        nickname: true,
+        phone: true,
+        reformer_auth: {
+          select: {
+            portfolio: true,
+            photo: true,
+            business_number: true
+          }
+        }
+      }
+    });
   }
 }

--- a/src/routes/users/users.service.ts
+++ b/src/routes/users/users.service.ts
@@ -4,7 +4,8 @@ import {
   UsersInfoResponse, 
   UpdateReformerProfileResponseDto, 
   UserDetailInfoResponseDto, 
-  ReformerDetailInfoResponseDto 
+  ReformerDetailInfoResponseDto,
+  ReformerPortfolioDto
 } from './dto/users.res.dto.js';
 import { SolapiMessageService} from 'solapi';
 import { 
@@ -17,7 +18,7 @@ import {
 import { validateNickname } from '../../utils/validators.js';
 import { 
   UsersModel, 
-  UserProfile 
+  UserProfile
 } from './users.model.js';
 import { 
   EmailDuplicateError,
@@ -31,6 +32,7 @@ import {
 } from './users.error.js';
 import { UsersRepository } from './users.repository.js';
 import { AuthStatus } from '../auth/auth.dto.js';
+import { reformer_status_enum } from '@prisma/client';
 
 const messageService = new SolapiMessageService(
   process.env.SOLAPI_API_KEY || '',
@@ -171,6 +173,15 @@ export class UsersService {
       throw new AccountNotFoundError('존재하지 않는 유저 계정입니다.')
     }
     return UserProfile.create(userProfile)
+  }
+
+  // 리폼러 포트폴리오 정보 조회
+  async getReformerPortfolios(status: reformer_status_enum): Promise<ReformerPortfolioDto[]> {
+    const reformerPortfolios = await this.usersRepository.getReformerPortfolios(status);
+    const dtos : ReformerPortfolioDto[] = reformerPortfolios.map((item) => {
+      return ReformerPortfolioDto.fromRaw(item)
+    })
+    return dtos
   }
 
   private async sendNotificationSms(phone: string | null, status: string) {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -76,7 +76,7 @@ export const validateRegistrationType = (
 };
 
 export const validateBusinessNumber = (businessNumber: string): void => {
-  if (!/^[0-9]{3}-[0-9]{2}-[0-9]{5}$/.test(businessNumber)){
+  if (!/^[0-9]{10}$/.test(businessNumber)){
     throw new InvalidBusinessNumberError(`${businessNumber} 는 올바른 사업자 번호 형식이 아닙니다.`);
   }
 };


### PR DESCRIPTION
## 개요

리폼러가 입력한 포트폴리오 정보를 조회할 페이지가 필요해 보여 이를 불러오는 API를 작성했습니다. 
리폼러 회원가입 시 입력하는 사업자 번호가 선택사항, 숫자만 입력이라는 것을 파악하여 사소한 변경사항이라 이번 이슈에 포함시켜 반영했습니다. 

## 주요 변경 사항

- [x] GET 'users/reformers' 를 작성함
- [x] POST 'users/signup/reformer'의 requestBody의 businessNumber의 입력을 optional하게 변경함

## 관련 이슈/마일스톤

- Closes #132 
- Relates to #132

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

## 기타 참고
