### PR TITLE
Feat : 마켓 카테고리 계층 조회 및 평점순 정렬 옵션 추가

### DIFF
--- a/src/routes/market/dto/market.req.dto.ts
+++ b/src/routes/market/dto/market.req.dto.ts
@@ -6,8 +6,8 @@ export class GetItemListRequestDto {
   category_id?: string;
 
   @IsOptional()
-  @IsIn(['popular', 'latest'])
-  sort?: 'popular' | 'latest';
+  @IsIn(['popular', 'latest', 'rating'])
+  sort?: 'popular' | 'latest' | 'rating';
 
   @IsOptional()
   @IsInt()

--- a/src/routes/market/market.controller.ts
+++ b/src/routes/market/market.controller.ts
@@ -62,7 +62,7 @@ export class MarketController extends Controller {
    * 상품 목록 조회
    * @summary 마켓 상품 목록을 조회합니다
    * @param categoryId 카테고리 ID (선택)
-   * @param sort 정렬 기준 (popular/latest, 기본: popular)
+   * @param sort 정렬 기준 (popular/latest/rating, 기본: popular)
    * @param page 페이지 번호 (기본: 1)
    * @param limit 페이지당 개수 (기본: 15)
    * @returns 상품 목록 조회 결과
@@ -79,7 +79,7 @@ export class MarketController extends Controller {
         reason: '입력값 검증 실패',
         data: [
           { field: 'categoryId', value: 'invalid', messages: 'categoryId는 UUID 형식이어야 합니다' },
-          { field: 'sort', value: 'invalid', messages: 'sort는 popular 또는 latest여야 합니다' },
+          { field: 'sort', value: 'invalid', messages: 'sort는 popular, latest, rating 중 하나여야 합니다' },
           { field: 'page', value: 0, messages: 'page는 1 이상의 정수여야 합니다' },
           { field: 'limit', value: 101, messages: 'limit는 1 이상 100 이하의 정수여야 합니다' }
         ]
@@ -126,7 +126,7 @@ export class MarketController extends Controller {
   public async getItemList(
     @Request() req: ExpressRequest,
     @Query() categoryId?: string,
-    @Query() sort: 'popular' | 'latest' = 'popular',
+    @Query() sort: 'popular' | 'latest' | 'rating' = 'popular',
     @Query() page: number = 1,
     @Query() limit: number = 15
   ): Promise<TsoaResponse<GetItemListResponseDto>> {

--- a/src/routes/market/market.repository.ts
+++ b/src/routes/market/market.repository.ts
@@ -14,6 +14,24 @@ export class MarketRepository {
   }
 
   /**
+   * 해당 카테고리 ID 및 모든 하위 카테고리 ID 목록 조회
+   */
+  async findDescendantCategoryIds(parentId: string): Promise<string[]> {
+    const rows = await this.findCategories();
+    const byParent = new Map<string | null, typeof rows>();
+    for (const r of rows) {
+      const key = r.parent_id;
+      if (!byParent.has(key)) byParent.set(key, []);
+      byParent.get(key)!.push(r);
+    }
+    const collect = (id: string): string[] => {
+      const children = byParent.get(id) ?? [];
+      return [id, ...children.flatMap((c) => collect(c.category_id))];
+    };
+    return collect(parentId);
+  }
+
+  /**
    * 카테고리 전체 목록 조회 (sort_order, depth 기준 정렬)
    */
   async findCategories() {
@@ -33,7 +51,7 @@ export class MarketRepository {
    * 상품 목록 조회 (필터 및 정렬 적용)
    */
   async findItemsWithFilters(
-    categoryFilter: { category_id?: string } | {},
+    categoryFilter: Prisma.itemWhereInput,
     orderBy: Prisma.itemOrderByWithRelationInput | Prisma.itemOrderByWithRelationInput[],
     skip: number,
     take: number
@@ -66,7 +84,7 @@ export class MarketRepository {
   /**
    * 상품 개수 조회
    */
-  async countItems(categoryFilter: { category_id?: string } | {}): Promise<number> {
+  async countItems(categoryFilter: Prisma.itemWhereInput): Promise<number> {
     return await prisma.item.count({
       where: categoryFilter
     });

--- a/src/routes/market/market.service.ts
+++ b/src/routes/market/market.service.ts
@@ -65,7 +65,7 @@ export class MarketService {
    */
   async getItemList(
     categoryId: string | undefined,
-    sort: 'popular' | 'latest',
+    sort: 'popular' | 'latest' | 'rating',
     page: number,
     limit: number,
     userId: string | undefined
@@ -73,16 +73,31 @@ export class MarketService {
     try {
       const skip = (page - 1) * limit;
 
-      const categoryFilter = categoryId ? { category_id: categoryId } : {};
+      let categoryFilter: Prisma.itemWhereInput;
+      if (categoryId) {
+        const categoryIds = await this.repository.findDescendantCategoryIds(categoryId);
+        categoryFilter =
+          categoryIds.length <= 1
+            ? { category_id: categoryId }
+            : { category_id: { in: categoryIds } };
+      } else {
+        categoryFilter = {};
+      }
 
       const orderBy =
         sort === 'latest'
           ? { created_at: 'desc' as const }
-          : [
-              { review_count: 'desc' as const },
-              { avg_star: 'desc' as const },
-              { created_at: 'desc' as const }
-            ];
+          : sort === 'rating'
+            ? [
+                { avg_star: 'desc' as const },
+                { review_count: 'desc' as const },
+                { created_at: 'desc' as const }
+              ]
+            : [
+                { review_count: 'desc' as const },
+                { avg_star: 'desc' as const },
+                { created_at: 'desc' as const }
+              ];
 
       const [items, totalCount] = await Promise.all([
         this.repository.findItemsWithFilters(categoryFilter, orderBy, skip, limit),


### PR DESCRIPTION
## 제목

Feat : 마켓 카테고리 계층 조회 및 평점순 정렬 옵션 추가

## 개요

마켓 카테고리 계층 조회 및 평점순 정렬 옵션 추가

## 주요 변경 사항

- [x] 상위 카테고리별 하위 전체 조회 추가
- [x] 평점순 정렬 옵션 추가

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #136 
- Relates to #136 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
