### PR TITLE
Feat : 구매 이력 목록 조회 및 상세 조회에 FEED 기능 추가

### DIFF
--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -130,6 +130,7 @@ export interface OrderResponseDto {
   thumbnail: string;
   reviewAvailable: boolean;
   reviewId: UUID | null;
+  chat_room_id: string;
 }
 
 export interface OrderListResponseDto {

--- a/src/routes/profile/profile.controller.ts
+++ b/src/routes/profile/profile.controller.ts
@@ -346,7 +346,6 @@ export class ProfileController extends Controller {
   ): Promise<TsoaResponse<OrderListResponseDto>> {
     const payload = req.user;
     const userId = payload.id;
-    // console.log(userId);
     const dto = new OrderRequestDto(
       type,
       cursor,

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -256,6 +256,7 @@ export type RawOrderData = Prisma.orderGetPayload<{
     target_type: true;
     quantity: true;
     tracking_number: true;
+    chat_room_id: true;
     owner: {
       select: {
         nickname: true;
@@ -265,12 +266,6 @@ export type RawOrderData = Prisma.orderGetPayload<{
       select: {
         created_at: true;
         receipt_number: true;
-        delivery_address: true;
-        delivery_address_detail: true;
-        delivery_address_name: true;
-        delivery_phone: true;
-        delivery_postal_code: true;
-        delivery_recipient_name: true;
       };
     };
     review: {
@@ -310,7 +305,8 @@ export class Order {
       ownerNickname: raw.owner.nickname ?? '',
       createdAt: raw.receipt?.created_at ?? new Date(),
       reviewAvailable: reviewAvailable,
-      reviewId: raw.review[0]?.review_id ?? null
+      reviewId: raw.review[0]?.review_id ?? null,
+      chat_room_id: raw.chat_room_id ?? ''
     });
   }
 

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -801,7 +801,7 @@ export class ProfileRepository {
     };
     const whereClause: any = {
       user_id: userId,
-      target_type: targetTypeFilter[type as keyof typeof targetTypeFilter] as target_type_enum | undefined,
+      target_type: targetTypeFilter[type as keyof typeof targetTypeFilter],
       status: { not: 'PENDING' }
     };
 

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -639,6 +639,7 @@ export class ProfileRepository {
         target_type: true,
         quantity: true,
         tracking_number: true,
+        chat_room_id: true,
         owner: {
           select: {
             nickname: true

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -689,6 +689,7 @@ export class ProfileRepository {
   }
 
   async getOptionIdsByOrderId(orderId: string): Promise<string[]> {
+    if (!orderId) return [];
     const optionIds = await prisma.order_option.findMany({
       where: { order_id: orderId },
       orderBy: [
@@ -712,6 +713,13 @@ export class ProfileRepository {
 
   async getOptionItemsWithGroup(optionItemIds: string[] | undefined ): Promise<RawOptionItemsWithGroup[]> {
     return await prisma.option_group.findMany({
+      where: {
+        option_item: {
+          some: {
+            option_item_id: { in: optionItemIds }
+          }
+        }
+      },
       orderBy: {
         sort_order: 'asc'
       },

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -310,25 +310,25 @@ export class ProfileRepository {
 
   async getFeedInfos(feedIds: string[]) {
     if(feedIds.length === 0) return [];
-    const feeds = await this.prisma.chat_proposal.findMany({
-      where: { chat_proposal_id: { in : feedIds } },
+    const feeds = await this.prisma.chat_request.findMany({
+      where: { chat_request_id: { in : feedIds } },
       select: {
-        chat_proposal_id: true,
+        chat_request_id: true,
+        message_id: true,
         title: true,
-        price: true,
-        delivery: true,
-        expected_working: true,
-        image: true
+        image: true,
+        min_budget: true,
+        max_budget: true
       }
     });
     return feeds.map((feed: (typeof feeds)[number]) => ({
-      chatProposalId: feed.chat_proposal_id,
-      title: feed.title ?? '',
-      photo : feed.image[0] ?? '',
-      price: feed.price ?? 0,
-      delivery: feed.delivery ?? 0,
-      expectedWorking: feed.expected_working ?? 0,
-      image: feed.image ?? []
+      chatRequestId: feed.chat_request_id,
+      messageId: feed.message_id,
+      title: feed.title,
+      photo: feed.image[0],
+      min_budget: feed.min_budget,
+      max_budget: feed.max_budget,
+      expectedWorking: feed.expected_working,
     }))
   }
 
@@ -636,12 +636,12 @@ export class ProfileRepository {
     };
     const whereClause : any = {
       user_id: userId,
-      target_type: targetTypeFilter[type as keyof typeof targetTypeFilter] as target_type_enum | undefined
+      target_type: targetTypeFilter[type as keyof typeof targetTypeFilter] as target_type_enum | undefined,
+      status: { not: 'PENDING' }
     };
     
     if (onlyReviewAvailable) {
       whereClause.review = { none: {} };
-      whereClause.status = { not: 'PENDING' };
     }
 
     const orders = await this.prisma.order.findMany({

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -308,6 +308,30 @@ export class ProfileRepository {
     }));
   }
 
+  async getFeedInfos(feedIds: string[]) {
+    if(feedIds.length === 0) return [];
+    const feeds = await this.prisma.chat_proposal.findMany({
+      where: { chat_proposal_id: { in : feedIds } },
+      select: {
+        chat_proposal_id: true,
+        title: true,
+        price: true,
+        delivery: true,
+        expected_working: true,
+        image: true
+      }
+    });
+    return feeds.map((feed: (typeof feeds)[number]) => ({
+      chatProposalId: feed.chat_proposal_id,
+      title: feed.title ?? '',
+      photo : feed.image[0] ?? '',
+      price: feed.price ?? 0,
+      delivery: feed.delivery ?? 0,
+      expectedWorking: feed.expected_working ?? 0,
+      image: feed.image ?? []
+    }))
+  }
+
   async getOrderDetail(
     ownerId: string,
     orderId: string
@@ -577,7 +601,7 @@ export class ProfileRepository {
   async getOrdersByUserId(dto: OrderRequestDto): Promise<RawOrderData[]> {
     const { userId, type, cursor, limit, order, onlyReviewAvailable } = dto;
     const targetTypeFilter = {
-      REFORM: { in: ['REQUEST', 'PROPOSAL'] },
+      REFORM: { in: ['REQUEST', 'PROPOSAL', 'FEED'] },
       ITEM: 'ITEM',
       ALL: undefined
     };

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -576,7 +576,7 @@ export class ProfileService {
     addToMap(itemInfos, 'item_id');
     addToMap(reqInfos, 'reform_request_id');
     addToMap(propInfos, 'reform_proposal_id');
-    addToMap(feedInfos, 'chatProposalId')
+    addToMap(feedInfos, 'chatRequestId')
 
     // 4. 모든 주문 목록 preview 생성
     const ordersPreview = actualOrders.map((order) => {

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -484,20 +484,23 @@ export class ProfileService {
     const itemIds = new Set<string>();
     const requestIds = new Set<string>();
     const proposalIds = new Set<string>();
+    const feedIds = new Set<string>();
 
     actualOrders.forEach(o => {
       if (!o.target_id) return;
       if (o.target_type === 'ITEM') itemIds.add(o.target_id);
       else if (o.target_type === 'REQUEST') requestIds.add(o.target_id);
       else if (o.target_type === 'PROPOSAL') proposalIds.add(o.target_id);
+      else if (o.target_type === 'FEED') feedIds.add(o.target_id);
     });
 
     
     // 3. title 과 thumbnail(photo) 조회
-    const [itemInfos, reqInfos, propInfos] = await Promise.all([
+    const [itemInfos, reqInfos, propInfos, feedInfos ] = await Promise.all([
       this.profileRepository.getItemInfos(Array.from(itemIds)),
       this.profileRepository.getRequestInfos(Array.from(requestIds)),
-      this.profileRepository.getProposalInfos(Array.from(proposalIds))
+      this.profileRepository.getProposalInfos(Array.from(proposalIds)),
+      this.profileRepository.getFeedInfos(Array.from(feedIds))
     ]);
 
     const infoMap = new Map<string, { title: string, thumbnail: string }>();
@@ -510,6 +513,7 @@ export class ProfileService {
     addToMap(itemInfos, 'item_id');
     addToMap(reqInfos, 'reform_request_id');
     addToMap(propInfos, 'reform_proposal_id');
+    addToMap(feedInfos, 'chatProposalId')
 
   // 4. 모든 주문 목록 preview 생성
   const ordersPreview = actualOrders.map((order) => {

--- a/src/routes/profile/profile.service.ts
+++ b/src/routes/profile/profile.service.ts
@@ -19,6 +19,7 @@ import {
   Sale,
   SaleDetail,
   OrderDetail,
+  RawOptionItemsWithGroup,
 } from './profile.model.js';
 import type {
   AddFeedResponseDto,
@@ -541,11 +542,15 @@ export class ProfileService {
     }
 
     // 2. 옵션 조회
-    const [info, optionItemIds] = await Promise.all([
-      this.getTargetInfo(order.target_type, order.target_id),
-      this.profileRepository.getOptionIdsByOrderId(orderId)
-    ])
-    const optionItemsWithGroup = await this.profileRepository.getOptionItemsWithGroup(optionItemIds);
+    const optionItemIds = await this.profileRepository.getOptionIdsByOrderId(orderId)
+    let optionItemsWithGroup: RawOptionItemsWithGroup[] = [];
+    if(optionItemIds.length > 0 ){
+      optionItemsWithGroup = await this.profileRepository.getOptionItemsWithGroup(optionItemIds);
+    }
+
+    const [info] = await Promise.all([
+      this.getTargetInfo(order.target_type, order.target_id)
+    ])    
     
     // 3. 결과값 리턴
     const orderDetail = OrderDetail.create(order,info?.title, info?.thumbnail, optionItemsWithGroup)
@@ -565,6 +570,9 @@ export class ProfileService {
       case 'REQUEST':
         const requests = await this.profileRepository.getRequestInfos([id]);
         return requests[0] ? { title: requests[0].title ?? '', thumbnail: requests[0].photo ?? ''} : undefined;
+      case 'FEED':
+        const feeds = await this.profileRepository.getFeedInfos([id]);
+        return feeds[0] ? { title: feeds[0].title ?? '', thumbnail: feeds[0].photo ?? ''} : undefined;
       default:
         return undefined;
     }


### PR DESCRIPTION
## 개요

target_type 'FEED' 추가에 따라 'FEED' 게시물을 불러올 필요성이 생겼고 이에 따라
FEED 게시물에 필요한 정보(title, thumbnail)를 불러오는 로직을 작성함

## 주요 변경 사항

- [ ] GET /profile/orders 수정
- [ ] GET /profile/orders/{id} 수정
각 API 내부에 FEED에서 title과 thumbnail을 받아오는 로직 작성

## 관련 이슈/마일스톤

- Closes #116
- Relates to #116

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)