### PR TITLE
Fix : 마켓 카테고리 2뎁스에만 나오게 수정

### DIFF
--- a/src/routes/market/market.service.ts
+++ b/src/routes/market/market.service.ts
@@ -49,10 +49,13 @@ export class MarketService {
       const items = (byParent.get(parentId) ?? []).sort((a, b) => a.sortOrder - b.sortOrder);
       return items.map((item) => {
         const subChildren = buildTree(item.categoryId);
-        const children: CategoryTreeItemDto[] = [
-          { categoryId: item.categoryId, name: '전체', sortOrder: 0, children: [] },
-          ...subChildren
-        ];
+        const isSecondDepth = parentId === null;
+        const children: CategoryTreeItemDto[] = isSecondDepth
+          ? [
+              { categoryId: item.categoryId, name: '전체', sortOrder: 0, children: [] },
+              ...subChildren
+            ]
+          : subChildren;
         return {
           categoryId: item.categoryId,
           name: item.name,


### PR DESCRIPTION
## 제목

Fix : 마켓 카테고리 2뎁스에만 나오게 수정

## 개요

마켓 카테고리 2뎁스에만 나오게 수정

## 주요 변경 사항

- [x] 마켓 카테고리 2뎁스에만 나오게 수정

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #136
- Relates to #136

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
