### PR TITLE
Feat : 리폼러 포트폴리오 조회 일부 기능 추가

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -137,7 +137,7 @@ export class AuthController extends Controller {
           sameSite: 'none'
         });
         const redirectUrl = (user.redirectUrl) 
-          ? `${process.env.FRONTENT_BASE_URL}${user.redirectUrl}`
+          ? `${process.env.FRONTEND_BASE_URL}${user.redirectUrl}`
           : process.env.FRONTEND_BASE_URL
         return res.redirect(redirectUrl!);
       }

--- a/src/routes/users/dto/users.res.dto.ts
+++ b/src/routes/users/dto/users.res.dto.ts
@@ -1,5 +1,5 @@
 import { AuthStatus, Role } from '../../auth/auth.dto.js';
-import { owner, user } from '@prisma/client';
+import { owner, reformer_status_enum, user } from '@prisma/client';
 import { rawReformerPortfolio } from '../users.model.js';
 
 // 닉네임 중복 검사 응답 데이터
@@ -128,6 +128,7 @@ export class ReformerPortfolioDto {
   introduction: string | null;
   photos: string[] | null;
   business_number: string | null;
+  status: reformer_status_enum;
 
   constructor(data: {
     owner_id: string;
@@ -138,6 +139,7 @@ export class ReformerPortfolioDto {
     portfolio: string | null;
     photos: string[] | null;
     business_number: string | null;
+    status: reformer_status_enum;
   }) {
     this.owner_id = data.owner_id;
     this.name = data.name;
@@ -147,6 +149,7 @@ export class ReformerPortfolioDto {
     this.introduction = data.portfolio;
     this.photos = data.photos;
     this.business_number = data.business_number;
+    this.status = data.status;
   }
 
   static fromRaw(raw: rawReformerPortfolio): ReformerPortfolioDto {
@@ -158,6 +161,7 @@ export class ReformerPortfolioDto {
       nickname: raw.nickname,
       email: raw.email,
       phone: raw.phone,
+      status: raw.status,
       portfolio: auth?.portfolio ?? null,
       photos: auth?.photo ?? [],
       business_number: auth?.business_number ?? null,

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -222,19 +222,25 @@ export class UsersController extends Controller {
     return new ResponseHandler<UserProfileResponseDto>(userProfileDto);
   }
 
-  /**
+/**
    * 인증 상태 별 리폼러 가입 시 입력 정보 불러오기
    * @summary 인증 상태 별로 리폼러의 포트폴리오 정보를 불러옵니다.
+   * @param status 리폼러의 인증 상태 (ALL: 전체, PENDING: 대기, APPROVED: 승인, REJECTED: 반려)
+   * @param page 조회할 페이지 번호 (기본값: 1)
+   * @param limit 한 페이지에 표시할 아이템 개수 (기본값: 10)
+   * @param order 정렬 기준 (desc: 최신순, asc: 오래된순) (기본값: 최신순)
    * @returns 리폼러 회원 정보 및 회원가입 시 입력 내용
    */
   @SuccessResponse(200, '리폼러 포트폴리오 정보 조회 성공')
   @Response<ErrorResponse>('500', '서버 오류')
   @Get('reformers')
   public async getReformersPortfolio(
-    @Query() status: reformer_status_enum,
-  )
-  : Promise<TsoaResponse<ReformerPortfolioDto[]>> {
-    const reformerPortfolios = await this.usersService.getReformerPortfolios(status);
-    return new ResponseHandler<ReformerPortfolioDto[]>(reformerPortfolios)
+    @Query() status: reformer_status_enum | 'ALL',
+    @Query() page: number = 1,
+    @Query() limit: number = 10,
+    @Query() order: 'desc' | 'asc' = 'desc'
+  ): Promise<TsoaResponse< {totalCount: number, data: ReformerPortfolioDto[]}>> {
+    const result = await this.usersService.getReformerPortfolios(status, page, limit, order);
+    return new ResponseHandler< { totalCount: number; data: ReformerPortfolioDto[]}>(result)
   }
 }

--- a/src/routes/users/users.model.ts
+++ b/src/routes/users/users.model.ts
@@ -247,5 +247,3 @@ export type rawReformerPortfolio = Prisma.ownerGetPayload<{
     }
   }  
 }>
-
-export type reformerPotfolioStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'ALL'

--- a/src/routes/users/users.model.ts
+++ b/src/routes/users/users.model.ts
@@ -248,3 +248,4 @@ export type rawReformerPortfolio = Prisma.ownerGetPayload<{
   }  
 }>
 
+export type reformerPotfolioStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'ALL'

--- a/src/routes/users/users.repository.ts
+++ b/src/routes/users/users.repository.ts
@@ -76,26 +76,39 @@ export class UsersRepository {
     return userProfile
   }
 
-  async getReformerPortfolios(status: reformer_status_enum): Promise<rawReformerPortfolio[]> {
-    return await prisma.owner.findMany({
-      where: {
-        status: status
-      },
-      select: {
-        owner_id: true,
-        status: true,
-        email: true,
-        name: true,
-        nickname: true,
-        phone: true,
-        reformer_auth: {
-          select: {
-            portfolio: true,
-            photo: true,
-            business_number: true
+  async getReformerPortfolios(
+    status: reformer_status_enum | 'ALL',
+    page: number,
+    limit: number,
+    order: 'asc' | 'desc'
+  ): Promise<{ totalCount: number; items: rawReformerPortfolio[] }> {
+    const whereCondition = status !== 'ALL' ? { status } : {};
+    const [totalCount, items] = await Promise.all([
+      prisma.owner.count({ where : whereCondition }),
+      prisma.owner.findMany({
+        where: whereCondition,
+        skip: (page - 1) * limit,
+        take: limit,
+        select: {
+          owner_id: true,
+          status: true,
+          email: true,
+          name: true,
+          nickname: true,
+          phone: true,
+          reformer_auth: {
+            select: {
+              portfolio: true,
+              photo: true,
+              business_number: true
+            }
           }
+        },
+        orderBy: {
+          created_at: order
         }
-      }
-    });
+      })
+    ])
+    return { totalCount, items };
   }
 }

--- a/src/routes/users/users.service.ts
+++ b/src/routes/users/users.service.ts
@@ -176,12 +176,18 @@ export class UsersService {
   }
 
   // 리폼러 포트폴리오 정보 조회
-  async getReformerPortfolios(status: reformer_status_enum): Promise<ReformerPortfolioDto[]> {
-    const reformerPortfolios = await this.usersRepository.getReformerPortfolios(status);
-    const dtos : ReformerPortfolioDto[] = reformerPortfolios.map((item) => {
-      return ReformerPortfolioDto.fromRaw(item)
-    })
-    return dtos
+  async getReformerPortfolios(
+    status: reformer_status_enum | 'ALL',
+    page: number,
+    limit: number,
+    order: 'asc' | 'desc'
+  ): Promise< { totalCount: number, data: ReformerPortfolioDto[] }> {
+    const { totalCount, items } = await this.usersRepository.getReformerPortfolios(status, page, limit, order);
+    const dtos = items.map((item) => ReformerPortfolioDto.fromRaw(item))
+    return {
+      totalCount, 
+      data: dtos 
+    }
   }
 
   private async sendNotificationSms(phone: string | null, status: string) {


### PR DESCRIPTION
## 개요
리폼러 포트폴리오 조회 UI 확정에 따라 일부 기능을 추가함

## 주요 변경 사항
- [x] 페이지네이션 추가
- [x] 전체 조회 기능 추가

## 관련 이슈/마일스톤
- Closes #144
- Relates to #144

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)