### PR TITLE
Feat : 리뷰 생성 및 삭제 시 리폼러 별점 및 리뷰 수 갱신 로직 작성

### DIFF
--- a/src/routes/orders/orders.service.ts
+++ b/src/routes/orders/orders.service.ts
@@ -30,6 +30,7 @@ import { Decimal } from '@prisma/client/runtime/binary';
 import { CreateReviewRequestDto } from './dto/orders.req.dto.js';
 import { CreateReviewInput } from './orders.model.js';
 import { CreateReviewResponseDto } from './dto/orders.res.dto.js';
+import { ReviewsRepository } from '../reviews/reviews.repository.js';
 
 
 export class OrdersService {
@@ -40,7 +41,10 @@ export class OrdersService {
     OrdersService.ORDER_NUMBER_LENGTH
   );
 
-  constructor(private repository: OrdersRepository = new OrdersRepository()) {}
+  constructor(
+    private repository: OrdersRepository = new OrdersRepository(),
+    private reviewsRepository: ReviewsRepository = new ReviewsRepository()
+  ) {}
 
   /**
    * 옵션 검증 (공통 로직)
@@ -2298,15 +2302,22 @@ export class OrdersService {
     if (!order) {
       throw new OrderNotFoundError(orderId);
     }
-    if (order.status == order_status_enum.PENDING) {
+    if (order.status === order_status_enum.PENDING) {
       throw new ReviewNotAllowedError('해당 주문은 리뷰 작성 가능한 상태가 아닙니다.');
     }
     if (await this.repository.findReviewByOrderId(orderId)) {
       throw new ReviewAlreadyExistsError('해당 주문에 대한 리뷰가 이미 작성되었습니다.');
     }
-    const createReviewInput = new CreateReviewInput(orderId, userId, order.owner_id, requestBody);
-    const review = await this.repository.createReview(createReviewInput);
-    const createReviewResponse = new CreateReviewResponseDto(review);
-    return createReviewResponse;
+    return await runInTransaction(async () => {
+      const createReviewInput = new CreateReviewInput(orderId, userId, order.owner_id, requestBody);
+      const review = await this.repository.createReview(createReviewInput);
+      const createReviewResponse = new CreateReviewResponseDto(review);
+      const ownerId = order.owner_id
+      const reformerReviewstat = await this.reviewsRepository.getReformerReviewStat(ownerId);
+      const reviewCount = reformerReviewstat._count.review_id
+      const avgStar = reformerReviewstat._avg.star
+      await this.reviewsRepository.syncReformerReviewStat(ownerId, reviewCount, avgStar)
+      return createReviewResponse;
+    });
   }
 }

--- a/src/routes/reviews/reviews.model.ts
+++ b/src/routes/reviews/reviews.model.ts
@@ -163,3 +163,15 @@ export interface ProposalReviewStats {
   photoReviewCount: number;
   reviewPhotos: string[];
 }
+
+export type ReviewStatData = Prisma.GetReviewAggregateType<{
+  where: {
+      owner_id: string;
+  };
+  _count: {
+      review_id: true;
+  };
+  _avg: {
+      star: true;
+  };
+}>

--- a/src/routes/reviews/reviews.repository.ts
+++ b/src/routes/reviews/reviews.repository.ts
@@ -1,5 +1,5 @@
 import prisma from '../../config/prisma.config.js';
-import { review } from '@prisma/client';
+import { review, owner } from '@prisma/client';
 import { PrismaClient } from '@prisma/client/extension';
 import {
   RawItemInfo,
@@ -10,7 +10,8 @@ import {
   UnifiedProductInfo,
   RawProposalReviewData,
   ProposalReviewStats,
-  ProposalReviewSortBy
+  ProposalReviewSortBy,
+  ReviewStatData
 } from './reviews.model.js';
 
 export class ReviewsRepository {
@@ -301,7 +302,6 @@ export class ReviewsRepository {
       }
     });
   }
-
   private getReviewSortOrder(sortBy: ProposalReviewSortBy) {
     switch (sortBy) {
       case 'high_rating':
@@ -312,5 +312,29 @@ export class ReviewsRepository {
       default:
         return { created_at: 'desc' as const };
     }
+  }
+
+  async getReformerReviewStat(
+    reformerId: string 
+  ): Promise<ReviewStatData> {
+    return await prisma.review.aggregate({
+      where: { owner_id: reformerId }, 
+      _count: { review_id: true },
+      _avg: { star: true }
+    });
+  }
+
+  async syncReformerReviewStat(
+    reformerId: string,
+    reviewCount: number,
+    avgStar: number | null
+  ): Promise<owner> {
+    return await prisma.owner.update({
+      where: { owner_id: reformerId},
+      data: { 
+        review_count: reviewCount,
+        avg_star: avgStar
+      }
+    })
   }
 }

--- a/src/routes/reviews/reviews.service.ts
+++ b/src/routes/reviews/reviews.service.ts
@@ -115,6 +115,7 @@ export class ReviewsService {
 
   async deleteReview(userId: string, reviewId: string): Promise<string> {
     const review = await this.reviewsRepository.findReviewById(reviewId);
+    const ownerId = review?.owner_id!;
     if (!review) {
       throw new ReviewNotFoundError('리뷰를 찾을 수 없습니다.');
     }
@@ -124,6 +125,10 @@ export class ReviewsService {
     return await runInTransaction(async () => {
       await this.reviewsRepository.deleteReviewPhotos(reviewId);
       await this.reviewsRepository.deleteReview(reviewId);
+      const reformerReviewstat = await this.reviewsRepository.getReformerReviewStat(ownerId);
+      const reviewCount = reformerReviewstat._count.review_id
+      const avgStar = reformerReviewstat._avg.star
+      await this.reviewsRepository.syncReformerReviewStat(ownerId, reviewCount, avgStar)
       return '리뷰 삭제가 완료되었습니다.';
     });
   }


### PR DESCRIPTION
## 개요
리폼러 별점 및 리뷰 수를 갱신하는 로직이 부재함
이에 리뷰가 추가, 삭제될 때마다 리폼러의 별점이 갱신되는 로직을 추가함

## 주요 변경 사항

- [x] DELETE /reviews/{reviewId}
- [x] POST /orders/{orderId}/review
해당 부분 로직 작성함

## 관련 이슈/마일스톤
- Closes #153
- Relates to #153

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)
