### PR TITLE
Refactor : 주문 상세 조회 로직에 결과값에 채팅방 정보 추가

### DIFF
--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -164,6 +164,7 @@ export class OrderDetailResponseDto {
   deliveryPhone!: string;
   deliveryAddressName!: string;
   options!: RawOptionItemsWithGroup[];
+  chat_room_id!: string;
 }
 
 export class RequestsListResponseDto {

--- a/src/routes/profile/dto/profile.res.dto.ts
+++ b/src/routes/profile/dto/profile.res.dto.ts
@@ -164,7 +164,7 @@ export class OrderDetailResponseDto {
   deliveryPhone!: string;
   deliveryAddressName!: string;
   options!: RawOptionItemsWithGroup[];
-  chat_room_id!: string;
+  chatRoomId!: string;
 }
 
 export class RequestsListResponseDto {

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -429,7 +429,7 @@ export class OrderDetail {
       deliveryFee: delivery_fee,
       totalPrice: totalPrice,
       trackingNumber: raw.tracking_number ?? '',
-      chat_room_id: raw.chat_room_id ?? '',
+      chatRoomId: raw.chat_room_id ?? '',
       createdAt: raw.receipt?.created_at ?? new Date(),
       receiptNumber: raw.receipt?.receipt_number ?? '',
       deliveryPostalCode: raw.receipt?.delivery_postal_code ?? '',

--- a/src/routes/profile/profile.model.ts
+++ b/src/routes/profile/profile.model.ts
@@ -373,6 +373,7 @@ export type RawOrderDetailData = Prisma.orderGetPayload<{
     delivery_fee: true;
     target_type: true;
     tracking_number: true;
+    chat_room_id: true;
     receipt: {
       select: {
         created_at: true;
@@ -428,6 +429,7 @@ export class OrderDetail {
       deliveryFee: delivery_fee,
       totalPrice: totalPrice,
       trackingNumber: raw.tracking_number ?? '',
+      chat_room_id: raw.chat_room_id ?? '',
       createdAt: raw.receipt?.created_at ?? new Date(),
       receiptNumber: raw.receipt?.receipt_number ?? '',
       deliveryPostalCode: raw.receipt?.delivery_postal_code ?? '',

--- a/src/routes/profile/profile.repository.ts
+++ b/src/routes/profile/profile.repository.ts
@@ -868,6 +868,7 @@ export class ProfileRepository {
         price: true,
         delivery_fee: true,
         tracking_number: true,
+        chat_room_id: true,
         receipt: {
           select: {
             created_at: true,


### PR DESCRIPTION
## 개요

주문 상세 조회 로직에 채팅방 정보(chatRoomId)를 추가함

## 주요 변경 사항

- [x] GET profile/orders/{orderId}에 chat_room_id를 추가함


## 관련 이슈/마일스톤
- Closes #174 
- Relates to #174 

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)