### PR TITLE
Refactor : 리폼러 인증 상태 변경 기능 권한 제한

### DIFF
--- a/src/routes/auth/authHandler.ts
+++ b/src/routes/auth/authHandler.ts
@@ -24,20 +24,29 @@ export function expressAuthentication(
       // Access Token 검증
       jwt.verify(token as string, jwtSecret, (err: any, decoded: any) => {
         if (err) reject(new UnauthorizedError('토큰이 유효하지 않은 Access Token입니다. 재로그인이 필요합니다.'));
-        
+
         // 역할 권한 검증
         // 사용 예 : @Security('jwt', ['user'])
         if (scopes && scopes.length > 0) {
-          if (!scopes.includes(decoded.role)) {
+          // 마스터 권한 검증
+          if (scopes.includes('master')) {
+            const masterId = process.env.MASTER_REFORMER;
+            if (decoded.id !== masterId) {
+              return reject(new ForbiddenError('해당 리소스에 접근 권한이 없습니다. 마스터 리폼러만 접근 가능합니다.'));
+            }
+          }
+          // 일반 역할 검증 (master가 아닌 다른 역할이 요구될 때)
+          else if (!scopes.includes(decoded.role)) {
             reject(new ForbiddenError('해당 리소스에 접근 권한이 없습니다.'));
           }
+
           // 리폼러 인증 상태 검증 
           // 사용 예 : @Security('jwt', ['reformer:approved'])
-          if (scopes?.includes('reformer:approved')){
+          if (scopes?.includes('reformer:approved')) {
             if (decoded.role !== 'reformer' || decoded.auth_status !== 'APPROVED') {
               return reject(new ForbiddenError('리폼러 인증 상태가 승인되지 않았습니다.'));
             }
-          } 
+          }
         }
         resolve(decoded);
       });
@@ -52,7 +61,7 @@ export function expressAuthentication(
 
     return new Promise((resolve) => {
       if (!token) return resolve(null);
-      
+
       jwt.verify(token as string, jwtSecret, (err: any, decoded: any) => {
         if (err) return resolve(null);
         resolve(decoded);

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -1,27 +1,28 @@
-import { 
+import {
   Body,
-  Path, 
-  Post, 
-  Patch, 
-  Controller, 
-  Route, 
-  Tags, 
-  Query, 
-  SuccessResponse, 
-  Example, 
-  Response, 
-  Request, 
-  Security, 
-  Get 
+  Path,
+  Post,
+  Patch,
+  Controller,
+  Route,
+  Tags,
+  Query,
+  SuccessResponse,
+  Example,
+  Response,
+  Request,
+  Security,
+  Get
 } from 'tsoa';
 import { ErrorResponse, ResponseHandler, TsoaResponse } from '../../config/tsoaResponse.js';
 import { CheckNicknameResponseDto, UpdateReformerProfileResponseDto, UserProfileResponseDto, UsersInfoResponseDto } from './dto/users.res.dto.js';
 import { UpdateReformerStatusRequestDto, UpdateUserProfileRequestDto, UpdateReformerProfileRequestDto } from './dto/users.req.dto.js';
-import { 
-  UpdateUserProfileResponseDto, 
-  UserDetailInfoResponseDto, 
+import {
+  UpdateUserProfileResponseDto,
+  UserDetailInfoResponseDto,
   ReformerDetailInfoResponseDto,
-  ReformerPortfolioDto } from './dto/users.res.dto.js';
+  ReformerPortfolioDto
+} from './dto/users.res.dto.js';
 import { UsersService } from './users.service.js';
 import { UnauthorizedError } from '../auth/auth.error.js';
 import { Request as ExRequest } from 'express';
@@ -65,6 +66,7 @@ export class UsersController extends Controller {
    * @param requestBody 목표 상태 (PENDING, APPROVED, REJECTED)
    * @returns 리폼러 상태 업데이트 결과
    */
+  @Security('jwt', ['master'])
   @SuccessResponse(200, '리폼러 상태 업데이트 성공')
   @Example<ResponseHandler<UsersInfoResponseDto>>({
     resultType: 'SUCCESS',
@@ -78,6 +80,7 @@ export class UsersController extends Controller {
     }
   })
   @Response<ErrorResponse>('400', '목표 상태 형식 오류')
+  @Response<ErrorResponse>('403', '권한 없음, 마스터 리폼러 계정만 이용 가능')
   @Response<ErrorResponse>('500', '서버 내부 오류')
   @Patch('reformer/{reformerId}/status')
   public async updateReformerStatus(


### PR DESCRIPTION
## 개요

<!-- PR 목적과 변경 이유를 간단히 설명해주세요. -->

## 주요 변경 사항

- [x] PATCH /users/reformer/{reformerId}/status 의 이용 권한을 마스터 리폼러로 제한

## 관련 이슈/마일스톤

- Closes #181 
- Relates to #181 

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)