### PR TITLE
Feat : 회원가입 테스트용 계정 삭제 기능 추가

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -32,7 +32,8 @@ export const REDIS_KEYS = {
   AUTH_CODE : (phone:string) => `auth:${phone}`,
   VERIFIED: (phone:string) => `verified:${phone}`,
   BLOCK: (phone:string) => `block:${phone}`,
-  REFRESH_TOKEN: (userId:string) => `refreshToken:${userId}`
+  REFRESH_TOKEN: (userId:string) => `refreshToken:${userId}`,
+  BLACKLIST: (accessToken: string | undefined) => `blacklist:${accessToken}`
 };
 
 export { redisClient };

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -335,7 +335,7 @@ export class AuthController extends Controller {
    * @description 프론트엔드에서 회원가입 편의성을 위해 만들어진 기능입니다.
    * @returns 삭제 성공여부
    */
-  @SuccessResponse(204, '계정 삭제 성공')
+  @SuccessResponse(200, '계정 삭제 성공')
   @Example<ResponseHandler<string>>({
     resultType: 'SUCCESS',
     error: null,
@@ -356,12 +356,12 @@ export class AuthController extends Controller {
     const payload = req.user;
     const userId = payload.id;
     const role = payload.role;
+    await this.authService.withdraw(userId, role, accessToken);
     this.setStatus(200);
     this.setHeader('Set-Cookie', 'refreshToken=; HttpOnly; Secure; Max-Age=0; Path=/; SameSite=none');
-    await this.authService.withdraw(userId, role, accessToken);
     return new ResponseHandler<WithdrawResponseDto>(
       {
-        statusCode: 204,
+        statusCode: 200,
         message: '회원 탈퇴가 완료되었습니다. 다시 가입하실 수 있습니다.'
       }
     );

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -10,7 +10,8 @@ import {
   Tags,
   Request,
   Query,
-  Security
+  Security,
+  Delete
 } from 'tsoa';
 import {
   TsoaResponse,
@@ -25,7 +26,8 @@ import {
   VerifySmsResponseDto,
   SendSmsResponseDto,
   AuthPublicResponseDto,
-  LogoutResponseDto
+  LogoutResponseDto,
+  WithdrawResponseDto
 } from './dto/auth.res.dto.js';
 
 import {
@@ -43,7 +45,7 @@ import {
 } from './dto/auth.req.dto.js';
 import express from 'express';
 import passport from './passport.js';
-import { KakaoAuthError } from './auth.error.js';
+import { KakaoAuthError, UnauthorizedError } from './auth.error.js';
 
 @Route('auth')
 @Tags('인증 기능')
@@ -190,9 +192,14 @@ export class AuthController extends Controller {
   async logout(
     @Request() req: ExRequest,
   ): Promise<TsoaResponse<LogoutResponseDto>> {
+    const authHeader = req.headers.authorization;
+    const accessToken = authHeader && authHeader.split(' ')[1];
+    if (!accessToken){
+      throw new UnauthorizedError('액세스 토큰을 찾을 수 없어 무효화할 수 없습니다.')
+    }
     const payload = req.user;
     const userId = payload.id;
-    await this.authService.logout(userId);
+    await this.authService.logout(userId, accessToken);
     this.setStatus(200);
     this.setHeader('Set-Cookie', 'refreshToken=; HttpOnly; Secure; Max-Age=0; Path=/; SameSite=none');
     return new ResponseHandler<LogoutResponseDto>({
@@ -321,5 +328,42 @@ export class AuthController extends Controller {
     return new ResponseHandler<AuthPublicResponseDto>({
       accessToken: accessToken
     });
+  }
+
+  /**
+   * @summary [프론트 테스트용] 가입된 계정을 삭제합니다.
+   * @description 프론트엔드에서 회원가입 편의성을 위해 만들어진 기능입니다.
+   * @returns 삭제 성공여부
+   */
+  @SuccessResponse(204, '계정 삭제 성공')
+  @Example<ResponseHandler<string>>({
+    resultType: 'SUCCESS',
+    error: null,
+    success: "회원 탈퇴가 완료되었습니다. 다시 가입하실 수 있습니다."
+  })
+  @Response<ErrorResponse>(403, '마스터 리폼러 계정은 삭제할 수 없습니다.')
+  @Response<ErrorResponse>(404, '삭제하려는 계정을 찾을 수 없습니다. 이미 삭제되었거나 없는 계정입니다.')
+  @Security('jwt')
+  @Delete('withdraw')
+  public async withdraw(
+    @Request() req: ExRequest,
+  ): Promise<ResponseHandler<WithdrawResponseDto>> {
+    const authHeader = req.headers.authorization;
+    const accessToken = authHeader && authHeader.split(' ')[1];
+    if (!accessToken){
+      throw new UnauthorizedError('액세스 토큰을 찾을 수 없어 무효화할 수 없습니다.')
+    }
+    const payload = req.user;
+    const userId = payload.id;
+    const role = payload.role;
+    this.setStatus(200);
+    this.setHeader('Set-Cookie', 'refreshToken=; HttpOnly; Secure; Max-Age=0; Path=/; SameSite=none');
+    await this.authService.withdraw(userId, role, accessToken);
+    return new ResponseHandler<WithdrawResponseDto>(
+      {
+        statusCode: 204,
+        message: '회원 탈퇴가 완료되었습니다. 다시 가입하실 수 있습니다.'
+      }
+    );
   }
 }

--- a/src/routes/auth/auth.repository.ts
+++ b/src/routes/auth/auth.repository.ts
@@ -1,5 +1,6 @@
 import { OwnerCreateInput, UserCreateInput } from './auth.model.js'
 import prisma from "../../config/prisma.config.js";
+import { Role } from './dto/auth.dto.js';
 import { UserCreateResponse, OwnerCreateResponse } from './auth.model.js'
 
 export class AuthRepository {
@@ -93,5 +94,46 @@ export class AuthRepository {
       role: dbRole === 'USER' ? 'user' : 'reformer',
       auth_status: resultOwner.status
     } as OwnerCreateResponse;
+  }
+
+  async deleteSocialAccount(role: Role, accountId: string){
+    if (role === 'user'){
+      return await prisma.social_account.deleteMany(
+        {
+        where: { user_id: accountId }
+        }
+      )
+    }
+    else{
+      return await prisma.social_account.deleteMany(
+        {
+          where: { owner_id: accountId }
+        }
+      )
+    }
+  }
+
+  async deleteUserAccount(accountId: string){
+    return await prisma.user.delete(
+      {
+        where: { user_id: accountId }
+      }
+    )
+  }
+
+  async deleteReformerAccount(accountId: string){
+    return await prisma.owner.delete(
+      {
+        where: { owner_id: accountId }
+      }
+    )
+  }
+
+  async deleteReformerAuth(accountId: string){
+    return await prisma.reformer_auth.deleteMany(
+      {
+        where: { owner_id: accountId }
+      }
+    )
   }
 }

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -12,7 +12,8 @@ import {
   EmailDuplicateError, 
   InputValidationError, 
   SocialAccountDuplicateError,
-  reformerNotApprovedError
+  reformerNotApprovedError,
+  ForbiddenError
 } from './auth.error.js';
 import { SolapiMessageService} from 'solapi';
 import { redisClient } from '../../config/redis.js';
@@ -61,7 +62,7 @@ import {
 } from './dto/auth.req.dto.js';
 import { CustomJwt } from '../../@types/expreees.js';
 import { AuthRepository } from './auth.repository.js';
-
+import { runInTransaction } from '../../config/prisma.config.js';
 dotenv.config();
 
 const messageService = new SolapiMessageService(
@@ -199,9 +200,10 @@ export class AuthService {
   }
 
   // 로그아웃 처리 : Redis에서 Refresh Token 삭제
-  async logout(userId: string): Promise<void> {
+  async logout(userId: string, accessToken: string): Promise<void> {
     try {
-      await redisClient.del(REDIS_KEYS.REFRESH_TOKEN(userId));      
+      await redisClient.del(REDIS_KEYS.REFRESH_TOKEN(userId));  
+      await this.registerAccessTokenToBlacklist(accessToken)    
     } catch (error) {
       console.error(`[Logout] Redis refreshToken 삭제 실패 - userId: ${userId}`, error);
     }
@@ -343,6 +345,60 @@ export class AuthService {
       return { accessToken, refreshToken: newRefreshToken };
     } catch (error) {
       throw new RefreshTokenError('액세스 토큰 및 리프레시 토큰 재발급에 실패하였습니다.');
+    }
+  }
+
+  // 계정 하드 딜리트 (로그인 시 테스트용)
+  async withdraw(accountId: string, role: Role, accessToken: string) {
+    return await runInTransaction(async () => {
+      if (role === 'user') {
+        if (accountId === process.env.MASTER_USER){
+          throw new ForbiddenError('마스터 계정은 삭제할 수 없습니다.')
+        }
+        const userAccount = await this.usersRepository.findUserbyUserId(accountId);
+        if (!userAccount){
+          throw new AccountNotFoundError('삭제하려는 계정을 찾을 수 없습니다. 이미 삭제되었거나 없는 계정입니다.')
+        }
+        await this.authRepository.deleteSocialAccount(role, accountId);
+        await this.authRepository.deleteUserAccount(accountId);
+      } else {
+        if (accountId === process.env.MASTER_REFORMER){
+          throw new ForbiddenError('마스터 계정은 삭제할 수 없습니다.')
+        }
+        const ownerAccount = await this.usersRepository.findReformerById(accountId);
+        if (!ownerAccount){
+          throw new AccountNotFoundError('삭제하려는 계정을 찾을 수 없습니다. 이미 삭제되었거나 없는 계정입니다.')
+        }
+        await this.authRepository.deleteReformerAuth(accountId);
+        await this.authRepository.deleteSocialAccount(role, accountId);
+        await this.authRepository.deleteReformerAccount(accountId);
+      }
+
+      try {
+        await redisClient.del(REDIS_KEYS.REFRESH_TOKEN(accountId));
+        await this.registerAccessTokenToBlacklist(accessToken);      
+      } catch (error) {
+        console.error(`[Logout] Redis refreshToken 삭제 실패 - userId: ${accountId}`, error);
+      }
+    })
+  }
+
+  async registerAccessTokenToBlacklist(accessToken: string): Promise<void>{
+    try {
+      const decoded = jwt.decode(accessToken) as { exp?: number };
+      const now = Math.floor(Date.now() / 1000);
+      const exp = decoded?.exp || (now + 3600);
+      const remainingTime = exp - now;
+
+      if (remainingTime > 0) {
+        await redisClient.set(
+          REDIS_KEYS.BLACKLIST(accessToken),
+          'true',
+          { EX : remainingTime }
+        )
+      }
+    } catch (error) {
+      console.error('액세스 토큰 블랙리스트 추가에 실패했습니다.', error);
     }
   }
 

--- a/src/routes/auth/authHandler.ts
+++ b/src/routes/auth/authHandler.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import jwt from 'jsonwebtoken';
 import { ForbiddenError, UnauthorizedError } from './auth.error.js';
+import { redisClient, REDIS_KEYS } from '../../config/redis.js';
 
 /**
  * TSOA 전용 인증 핸들러 함수
@@ -9,7 +10,7 @@ import { ForbiddenError, UnauthorizedError } from './auth.error.js';
  * @param _scope scopes 권한 범위
  * @returns 
  */
-export function expressAuthentication(
+export async function expressAuthentication(
   request: express.Request,
   securityName: string,
   scopes?: string[]
@@ -18,9 +19,13 @@ export function expressAuthentication(
   if (securityName === 'jwt') {
     const authHeader = request.headers['authorization'];
     const token = authHeader && authHeader.split(' ')[1];
-
+    const isBlacklisted = await redisClient.get(REDIS_KEYS.BLACKLIST(token));
+    if (isBlacklisted) {
+      throw new UnauthorizedError('이미 로그아웃된 토큰입니다. 다시 로그인해주세요.');
+    }
     return new Promise((resolve, reject) => {
-      if (!token) reject(new UnauthorizedError('토큰이 없습니다.'));
+      if (!token) reject(new UnauthorizedError('토큰이 없습니다.'));     
+      
       // Access Token 검증
       jwt.verify(token as string, jwtSecret, (err: any, decoded: any) => {
         if (err) reject(new UnauthorizedError('토큰이 유효하지 않은 Access Token입니다. 재로그인이 필요합니다.'));

--- a/src/routes/auth/dto/auth.res.dto.ts
+++ b/src/routes/auth/dto/auth.res.dto.ts
@@ -40,6 +40,20 @@ export class LogoutResponseDto {
   }
 }
 
+// 계정 삭제 응답 데이터
+export class WithdrawResponseDto {
+  statusCode: number;
+  message: string;
+
+  constructor(
+    statusCode: number,
+    message: string
+  ) {
+    this.statusCode = statusCode,
+    this.message = message
+  }
+}
+
 // 공통 인증 응답 dto
 export class AuthPublicResponseDto{
   accessToken: string;


### PR DESCRIPTION
## 개요
프론트에서 회원가입 연동하면서 계정을 한 번 생성해버리면,
DB에서 계정을 삭제하지 않는 이상 재가입이 어려워 문제를 겪고 있습니다.
따라서 실제 탈퇴 기능이 아니고,프론트에서 쉽게 테스트할 수 있게 하는 용도로 생성된 기능입니다.
우선, 마스터 계정은 삭제하지 못하도록 설정해두었습니다.

## 주요 변경 사항
- [ ] DELETE auth/withdraw 계정 삭제 기능 구현 (프론트 테스트 용)
- [ ] 로그아웃 및 계정 삭제 시 기존의 accessToken 을 Redis 블랙리스트에 추가하여 재사용을 방지하는 로직 작성

## 관련 이슈/마일스톤

- Closes #187 
- Relates to #187 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)
