### PR TITLE
Fix : 재고 복구 로직 수정

### DIFF
--- a/src/routes/orders/orders.repository.ts
+++ b/src/routes/orders/orders.repository.ts
@@ -318,6 +318,26 @@ export class OrdersRepository {
     });
   }
 
+  /** UUID 형식 검증용 정규식 */
+  private static readonly UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  /**
+   * @returns 유효한 ID가 있으면 Prisma.Sql (IN 절용), 없으면 null
+   */
+  private optionItemIdsToSqlIn(optionItemIds: string[]): Prisma.Sql | null {
+    if (!optionItemIds?.length) return null;
+    const validIds = optionItemIds.filter(
+      (id): id is string =>
+        typeof id === 'string' && OrdersRepository.UUID_REGEX.test(id.trim())
+    );
+    if (validIds.length === 0) return null;
+    return Prisma.join(
+      validIds.map((id) => Prisma.sql`${id}::uuid`),
+      ', '
+    );
+  }
+
   /**
    * 옵션 아이템 재고 차감
    */
@@ -325,15 +345,21 @@ export class OrdersRepository {
     optionItemIds: string[],
     quantity: number
   ): Promise<number> {
-    return await prisma.$executeRaw(
+    if (optionItemIds.length === 0 || quantity < 1 || !Number.isInteger(quantity)) {
+      return 0;
+    }
+    const idsFragment = this.optionItemIdsToSqlIn(optionItemIds);
+    if (idsFragment === null) return 0;
+    const result = await prisma.$executeRaw(
       Prisma.sql`
         UPDATE option_item
         SET quantity = quantity - ${quantity}
-        WHERE option_item_id = ANY(${optionItemIds}::uuid[])
+        WHERE option_item_id IN (${idsFragment})
           AND quantity >= ${quantity}
           AND quantity IS NOT NULL
       `
     );
+    return Number(result);
   }
 
   /**
@@ -343,14 +369,20 @@ export class OrdersRepository {
     optionItemIds: string[],
     quantity: number
   ): Promise<number> {
-    return await prisma.$executeRaw(
+    if (optionItemIds.length === 0 || quantity < 1 || !Number.isInteger(quantity)) {
+      return 0;
+    }
+    const idsFragment = this.optionItemIdsToSqlIn(optionItemIds);
+    if (idsFragment === null) return 0;
+    const result = await prisma.$executeRaw(
       Prisma.sql`
         UPDATE option_item
         SET quantity = quantity + ${quantity}
-        WHERE option_item_id = ANY(${optionItemIds}::uuid[])
+        WHERE option_item_id IN (${idsFragment})
           AND quantity IS NOT NULL
       `
     );
+    return Number(result);
   }
 
   /**


### PR DESCRIPTION
## 제목

Fix : 재고 복구 로직 수정

## 개요

Prisma.join 패턴으로 변경하여 배열 파싱 단계 제거 함으로써 배열 구조 파싱이라는 위험 요소를 제거하고 스칼라 값 비교로 전환

## 주요 변경 사항

- [x] Prisma.join 패턴으로 변경하여 배열 파싱 단계 제거

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #185 
- Relates to #185 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
