### PR TITLE
feat : 반려된 리폼러 로그인 에러 처리 기능 추가

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -141,6 +141,24 @@ export class AuthController extends Controller {
   @SuccessResponse(200, '카카오 로그인 성공')
   @Response<ErrorResponse>('400', '입력한 mode의 값이 유효하지 않습니다.')
   @Response<ErrorResponse>('401', '카카오 인증에 성공했으나 유저 정보를 가져오지 못했습니다.')
+  @Response<ErrorResponse>('403', '리폼러 승인 대기 중 / 반려됨', {
+    resultType: "FAIL",
+    error: {
+      errorCode: "Auth_117",
+      reason: "승인 대기 중인 계정입니다.",
+      data: "승인 대기 중인 계정입니다."
+    },
+    success: null
+  })
+  @Response<ErrorResponse>('403', '리폼러 승인 대기 중 / 반려됨', {
+    resultType: "FAIL",
+    error: {
+      errorCode: "Auth_118",
+      reason: "리폼러 신청이 반려된 계정입니다.",
+      data: "리폼러 신청이 반려된 계정입니다."
+    },
+    success: null
+  })
   @Response<ErrorResponse>('500', '서버 내부 오류')
   @Get('kakao/callback')
   public async kakaoCallback(@Request() request: express.Request): Promise<void> {
@@ -276,6 +294,24 @@ export class AuthController extends Controller {
    */
   @SuccessResponse(200, '로컬 로그인 성공')
   @Response<ErrorResponse>('400', '입력한 정보가 올바르지 않습니다.')
+  @Response<ErrorResponse>('403', '리폼러 승인 대기 중 / 반려됨', {
+    resultType: "FAIL",
+    error: {
+      errorCode: "Auth_117",
+      reason: "승인 대기 중인 계정입니다.",
+      data: "승인 대기 중인 계정입니다."
+    },
+    success: null
+  })
+  @Response<ErrorResponse>('403', '리폼러 승인 대기 중 / 반려됨', {
+    resultType: "FAIL",
+    error: {
+      errorCode: "Auth_118",
+      reason: "리폼러 신청이 반려된 계정입니다.",
+      data: "리폼러 신청이 반려된 계정입니다."
+    },
+    success: null
+  })
   @Response<ErrorResponse>('500', '서버 내부 오류')
   @Example<ResponseHandler<AuthPublicResponseDto>>({
     resultType: 'SUCCESS',

--- a/src/routes/auth/auth.error.ts
+++ b/src/routes/auth/auth.error.ts
@@ -103,6 +103,12 @@ export class reformerNotApprovedError extends BasicError {
   }
 }
 
+export class reformerRejectedError extends BasicError {
+  constructor(description: string) {
+    super(403, 'Auth_118', '리폼러 신청이 반려된 계정입니다.', description)
+  }
+}
+
 export class SmsProviderError extends BasicError {
   constructor(description: string) {
     super(500, 'Auth_501', 'SMS 전송 중 오류가 발생했습니다.', description);

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -13,7 +13,8 @@ import {
   InputValidationError, 
   SocialAccountDuplicateError,
   reformerNotApprovedError,
-  ForbiddenError
+  ForbiddenError,
+  reformerRejectedError
 } from './auth.error.js';
 import { SolapiMessageService} from 'solapi';
 import { redisClient } from '../../config/redis.js';
@@ -181,10 +182,15 @@ export class AuthService {
       throw new MissingAuthInfoError('JWT 토큰 생성에 필요한 유저 정보가 DB에서 누락되었습니다.');
     }
     
-    if (user.role === 'reformer' && user.auth_status === 'PENDING'){
-      throw new reformerNotApprovedError('reformerNotApprovedError')
+    if (user.role === 'reformer') {
+      if (user.auth_status === 'PENDING') {
+        throw new reformerNotApprovedError('아직 승인되지 않은 리폼러입니다.')
+      }
+      if (user.auth_status === 'REJECTED') {
+        throw new reformerRejectedError('리폼러 신청이 반려된 계정입니다.')
+      }
     }
-
+    
     const payload: CustomJwt = {
       id: user.id,
       role: user.role,
@@ -299,10 +305,15 @@ export class AuthService {
       throw new passwordInvalidError('비밀번호가 일치하지 않습니다.');
     }
     
-    if (account.role === 'reformer' && account.auth_status === 'PENDING'){
-      throw new reformerNotApprovedError('아직 승인되지 않은 리폼러입니다.')
+    if (account.role === 'reformer') {
+      if (account.auth_status === 'PENDING') {
+        throw new reformerNotApprovedError('아직 승인되지 않은 리폼러입니다.')
+      }
+      if (account.auth_status === 'REJECTED') {
+        throw new reformerRejectedError('리폼러 신청이 반려된 계정입니다.')
+      }
     }
-    
+
     const payload: CustomJwt = {
       id: account.id,
       role: account.role,


### PR DESCRIPTION
## 개요

반려된 리폼러가 로그인 시도시 이를 차단하는 에러 처리가 부재하여 해당 기능을 추가함.

## 주요 변경 사항

- [ ] Auth_118 에러 추가 (반려된 리폼러 로그인 시도 시)
- [ ] 카카오 / 로컬 로그인 로직에 Auth_118 에러 추가함
- [ ] swagger 문서에 반영함

## 관련 이슈/마일스톤

- Closes #192 
- Relates to #192

## 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)