### PR TITLE
Refactor : 리프레시 토큰 기간 변경 및 카카오 로그인 에러 리다이렉트 추가

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -141,41 +141,31 @@ export class AuthController extends Controller {
   @SuccessResponse(200, '카카오 로그인 성공')
   @Response<ErrorResponse>('400', '입력한 mode의 값이 유효하지 않습니다.')
   @Response<ErrorResponse>('401', '카카오 인증에 성공했으나 유저 정보를 가져오지 못했습니다.')
-  @Response<ErrorResponse>('403', '리폼러 승인 대기 중 / 반려됨', {
-    resultType: "FAIL",
-    error: {
-      errorCode: "Auth_117",
-      reason: "승인 대기 중인 계정입니다.",
-      data: "승인 대기 중인 계정입니다."
-    },
-    success: null
-  })
-  @Response<ErrorResponse>('403', '리폼러 승인 대기 중 / 반려됨', {
-    resultType: "FAIL",
-    error: {
-      errorCode: "Auth_118",
-      reason: "리폼러 신청이 반려된 계정입니다.",
-      data: "리폼러 신청이 반려된 계정입니다."
-    },
-    success: null
-  })
   @Response<ErrorResponse>('500', '서버 내부 오류')
   @Get('kakao/callback')
   public async kakaoCallback(@Request() request: express.Request): Promise<void> {
     const res = request.res as express.Response;
-    const user = await this.authenticateKakao(request, res);
-    const result = await this.authService.handleKakaoLogin(user);
-    if (result.status == 'login') {
-      const loginUrl = `${process.env.FRONTEND_BASE_URL}/login/callback`
-      const redirectWithToken = `${loginUrl}?accessToken=${result.accessToken}&refreshToken=${result.refreshToken}&redirectUrl=${user.redirectUrl ?? ''}`;
-      return res.redirect(redirectWithToken);
-    }
+    try {
+      const user = await this.authenticateKakao(request, res);
+      const result = await this.authService.handleKakaoLogin(user);
+      if (result.status == 'login') {
+        const loginUrl = `${process.env.FRONTEND_BASE_URL}/login/callback`
+        const redirectWithToken = `${loginUrl}?accessToken=${result.accessToken}&refreshToken=${result.refreshToken}&redirectUrl=${user.redirectUrl ?? ''}`;
+        return res.redirect(redirectWithToken);
+      }
 
-    if (result.status == 'signup') {
-      const { role, kakaoId, email, redirectUrl } = result.user;
-      const signupUrl = `${process.env.FRONTEND_BASE_URL}/kakao/signup`
-      const redirectWithSignupInfo = `${signupUrl}?kakaoId=${kakaoId}&email=${email}&role=${role}&redirectUrl=${redirectUrl ?? ''}`;
-      return res.redirect(redirectWithSignupInfo);
+      if (result.status == 'signup') {
+        const { role, kakaoId, email, redirectUrl } = result.user;
+        const signupUrl = `${process.env.FRONTEND_BASE_URL}/kakao/signup`
+        const redirectWithSignupInfo = `${signupUrl}?kakaoId=${kakaoId}&email=${email}&role=${role}&redirectUrl=${redirectUrl ?? ''}`;
+        return res.redirect(redirectWithSignupInfo);
+      }
+    } catch (error: any) {
+      console.error('Kakao Login Error:', error);
+      const statusCode = error.status || 500;
+      const errorCode = error.code || 'UnknownError';
+      const loginUrl = `${process.env.FRONTEND_BASE_URL}/login/callback`
+      return res.redirect(`${loginUrl}?error=${errorCode}&status=${statusCode}`);
     }
   }
 
@@ -212,7 +202,7 @@ export class AuthController extends Controller {
   ): Promise<TsoaResponse<LogoutResponseDto>> {
     const authHeader = req.headers.authorization;
     const accessToken = authHeader && authHeader.split(' ')[1];
-    if (!accessToken){
+    if (!accessToken) {
       throw new UnauthorizedError('액세스 토큰을 찾을 수 없어 무효화할 수 없습니다.')
     }
     const payload = req.user;
@@ -386,7 +376,7 @@ export class AuthController extends Controller {
   ): Promise<ResponseHandler<WithdrawResponseDto>> {
     const authHeader = req.headers.authorization;
     const accessToken = authHeader && authHeader.split(' ')[1];
-    if (!accessToken){
+    if (!accessToken) {
       throw new UnauthorizedError('액세스 토큰을 찾을 수 없어 무효화할 수 없습니다.')
     }
     const payload = req.user;

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -435,7 +435,7 @@ export class AuthService {
 
   // JWT 토큰 생성 및 Redis에 저장
   private async generateAndSaveTokens(payload: CustomJwt): Promise<AuthLoginResponse> {
-    const accessToken = jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: '1h' });
+    const accessToken = jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: '5m' });
     const refreshToken = jwt.sign({id: payload.id, role: payload.role}, process.env.JWT_SECRET!, { expiresIn: '14d' });
     // Refresh Token Redis에 저장
     try {


### PR DESCRIPTION
<!-- 예: feat: 로그인 기능 구현 (#1) -->

## 개요
프론트 요청에 따라 리프레스 토큰 지속 시간 5분으로 변경,
카카오 로그인 에러 발생시 에러 정보를 포함하여 리다이렉트하는 방식으로 변경함

## 주요 변경 사항

- [x] 리프레시 토큰 기간 1h에서 5m으로 변경
- [x] 카카오 로그인 오류 발생시 에러 정보 담고 {baseUrl}/login/callback페이지로 리다이렉트


## 관련 이슈/마일스톤
- Closes #194 
- Relates to #194

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
