### PR TITLE
Feat  : 쿠키 설정 기능 일부 추가

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -209,7 +209,8 @@ export class AuthController extends Controller {
     const userId = payload.id;
     await this.authService.logout(userId, accessToken);
     this.setStatus(200);
-    this.setHeader('Set-Cookie', 'refreshToken=; HttpOnly; Secure; Max-Age=0; Path=/; SameSite=none');
+    const cookieOptions = this.getCookieOptions(0);
+    this.setHeader('Set-Cookie', `refreshToken=; ${cookieOptions}`);
     return new ResponseHandler<LogoutResponseDto>({
       statusCode: 200,
       message: '로그아웃이 성공적으로 완료되었습니다.(리프레쉬 토큰 무효화) 쿠키 삭제 후 프론트엔드에서 accessToken 삭제 필요'
@@ -238,7 +239,8 @@ export class AuthController extends Controller {
     const result = await this.authService.signupUser(requestBody);
     const { accessToken, refreshToken } = result;
     this.setStatus(201);
-    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; HttpOnly; Secure; Max-Age=1209600; Path=/; SameSite=none`);
+    const cookieOptions = this.getCookieOptions(1209600);
+    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; ${cookieOptions}`);
     return new ResponseHandler<AuthPublicResponseDto>({
       accessToken: accessToken
     });
@@ -269,7 +271,8 @@ export class AuthController extends Controller {
     const result = await this.authService.signupReformer(requestBody);
     const { accessToken, refreshToken } = result;
     this.setStatus(201);
-    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; HttpOnly; Secure; Max-Age=1209600; Path=/; SameSite=none`);
+    const cookieOptions = this.getCookieOptions(1209600);
+    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; ${cookieOptions}`);
     return new ResponseHandler<AuthPublicResponseDto>({
       accessToken: accessToken
     });
@@ -318,7 +321,8 @@ export class AuthController extends Controller {
     const result = await this.authService.loginLocal(requestBody);
     const { accessToken, refreshToken } = result;
     this.setStatus(200);
-    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; HttpOnly; Secure; Max-Age=1209600; Path=/; SameSite=none`);
+    const cookieOptions = this.getCookieOptions(1209600);
+    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; ${cookieOptions}`);
     return new ResponseHandler<AuthPublicResponseDto>({
       accessToken: accessToken
     });
@@ -350,7 +354,8 @@ export class AuthController extends Controller {
       .reissueAccessToken({ refreshToken: refreshTokenFromCookie });
     const { accessToken, refreshToken } = result;
     this.setStatus(200);
-    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; HttpOnly; Secure; Max-Age=1209600; Path=/; SameSite=none`);
+    const setOptions = this.getCookieOptions(1209600);
+    this.setHeader('Set-Cookie', `refreshToken=${refreshToken}; ${setOptions}`);
     return new ResponseHandler<AuthPublicResponseDto>({
       accessToken: accessToken
     });
@@ -384,12 +389,20 @@ export class AuthController extends Controller {
     const role = payload.role;
     await this.authService.withdraw(userId, role, accessToken);
     this.setStatus(200);
-    this.setHeader('Set-Cookie', 'refreshToken=; HttpOnly; Secure; Max-Age=0; Path=/; SameSite=none');
+    const cookieOptions = this.getCookieOptions(0);
+    this.setHeader('Set-Cookie', `refreshToken=; ${cookieOptions}`);
     return new ResponseHandler<WithdrawResponseDto>(
       {
         statusCode: 200,
         message: '회원 탈퇴가 완료되었습니다. 다시 가입하실 수 있습니다.'
       }
     );
+  }
+
+  private getCookieOptions(maxAge: number): string {
+    const isDevelopment = process.env.COOKIE_SETUP === 'development';
+    const sameSite = isDevelopment ? 'Lax' : 'None';
+    const secure = isDevelopment ? '' : 'Secure;';
+    return `HttpOnly; ${secure} Max-Age=${maxAge}; Path=/; SameSite=${sameSite}`;
   }
 }


### PR DESCRIPTION
## 개요

현재 쿠키 설정이 https 간 거래에 특화되어 있어 서버 간에는 제대로 작동하지만, 
프론트엔드 개발 과정에서 로컬에서 테스트하는 데 문제가 있습니다. 
환경 변수를 추가 및 쿠키 관련 코드를 일부 추가하여 프론트엔드 개발 환경에 맞게 설정하고자 합니다.

## 주요 변경 사항

- [ ] 쿠키를 로컬 테스트 단계에서는 Secure 해제, Lax로 설정하는 로직을 추가함

## 관련 이슈/마일스톤

- Closes #196 
- Relates to #196 

- [x] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [x] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [x] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [x] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)