### PR TITLE
fix : 리프레시 토큰 갱신 에러 처리 변경

### DIFF
--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -327,36 +327,32 @@ export class AuthService {
   // 리프레시 토큰을 입력받아 엑세스 토큰과 리프레시 토큰을 재발급
   async reissueAccessToken(requestBody: RefreshTokenRequest): Promise<AuthLoginResponse> {
     const { refreshToken } = requestBody;
-    try {
-      const decoded = jwt.verify(refreshToken, process.env.JWT_SECRET!);
-      const userId = (decoded as CustomJwt).id;
-      const role = (decoded as CustomJwt).role;
-      const savedRefreshToken = await redisClient.get(REDIS_KEYS.REFRESH_TOKEN(userId));
-      
-      if (!savedRefreshToken || savedRefreshToken !== refreshToken){
-        await redisClient.del(REDIS_KEYS.REFRESH_TOKEN(userId));
-        throw new InvalidCodeError('리프레시 토큰이 만료되었거나 일치하지 않습니다.');
-      }
-      
-      const account = (role === 'user'
-        ? await this.usersRepository.findUserById(userId)
-        : await this.usersRepository.findReformerById(userId)) as UsersInfoResponseDto;
-      
-      if (!account){
-        throw new AccountNotFoundError('존재하지 않는 유저입니다.');
-      }
-
-      const payload: CustomJwt = {
-        id: account.id,
-        role: account.role as 'user' | 'reformer',
-        ...(role === 'reformer' && { auth_status: account.auth_status as AuthStatus })
-      };
-
-      const { accessToken, refreshToken: newRefreshToken } = await this.generateAndSaveTokens(payload);
-      return { accessToken, refreshToken: newRefreshToken };
-    } catch (error) {
-      throw new RefreshTokenError('액세스 토큰 및 리프레시 토큰 재발급에 실패하였습니다.');
+    const decoded = jwt.verify(refreshToken, process.env.JWT_SECRET!);
+    const userId = (decoded as CustomJwt).id;
+    const role = (decoded as CustomJwt).role;
+    const savedRefreshToken = await redisClient.get(REDIS_KEYS.REFRESH_TOKEN(userId));
+    
+    if (!savedRefreshToken || savedRefreshToken !== refreshToken){
+      await redisClient.del(REDIS_KEYS.REFRESH_TOKEN(userId));
+      throw new InvalidCodeError('리프레시 토큰이 만료되었거나 일치하지 않습니다.');
     }
+    
+    const account = (role === 'user'
+      ? await this.usersRepository.findUserById(userId)
+      : await this.usersRepository.findReformerById(userId)) as UsersInfoResponseDto;
+    
+    if (!account){
+      throw new AccountNotFoundError('존재하지 않는 유저입니다.');
+    }
+
+    const payload: CustomJwt = {
+      id: account.id,
+      role: account.role as 'user' | 'reformer',
+      ...(role === 'reformer' && { auth_status: account.auth_status as AuthStatus })
+    };
+
+    const { accessToken, refreshToken: newRefreshToken } = await this.generateAndSaveTokens(payload);
+    return { accessToken, refreshToken: newRefreshToken };
   }
 
   // 계정 하드 딜리트 (로그인 시 테스트용)


### PR DESCRIPTION
## 개요

현재 리프레시 토큰 갱신부분이 제대로 작동하지 않아 에러 조회를 용이하게 수정함

## 주요 변경 사항

- [ ] try-catch 문을 삭제하여 에러 메시지 출력을 용이하게함

## 관련 이슈/마일스톤

- Closes #
- Relates to #

## 체크리스트

- [ ] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [ ] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [ ] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [ ] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)

## 스크린샷/로그

<!-- 필요시 첨부 -->

## 기타 참고

<!-- 레퍼런스/결정 배경 등 -->
