### PR TITLE
Hotfix : 액세스 토큰 만료 시간 증가

### DIFF
--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -431,7 +431,7 @@ export class AuthService {
 
   // JWT 토큰 생성 및 Redis에 저장
   private async generateAndSaveTokens(payload: CustomJwt): Promise<AuthLoginResponse> {
-    const accessToken = jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: '5m' });
+    const accessToken = jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: '1h' });
     const refreshToken = jwt.sign({id: payload.id, role: payload.role}, process.env.JWT_SECRET!, { expiresIn: '14d' });
     // Refresh Token Redis에 저장
     try {


### PR DESCRIPTION
## 제목
개발 편의성을 위해 액세스 토큰 만료 시간을 1시간으로 변경합니다.

## 개요
개발 편의성을 위해 액세스 토큰 만료 시간을 1시간으로 변경합니다.

## 주요 변경 사항

- [ ] 액세스토큰 발급 시 5m 에서 1h로 변경