### PR TITLE
Fix : 전체 리폼러탐색에 null인 필드 반영

### DIFF
--- a/src/routes/reformer/reformer.model.ts
+++ b/src/routes/reformer/reformer.model.ts
@@ -8,8 +8,8 @@ export type ReformerSearchResult = Omit<owner, 'search_vector'> & {
 };
 
 export type NameCursor = [string, string]; // [nickname, owner_id]
-export type RatingCursor = [number, string]; // [avg_star, owner_id]
-export type TradeCursor = [number, string]; // [trade_count, owner_id]
+export type RatingCursor = [number | null, string]; // [avg_star, owner_id]
+export type TradeCursor = [number | null, string]; // [trade_count, owner_id]
 export type SearchCursor = [number, number, string]; // [rank, avg_star, owner_id]
 export type FeedCursor = [string]; // [feed_id]
 
@@ -20,6 +20,17 @@ type FeedRow = {
   created_at: Date;
   photo_content: string | null;
   photo_count: bigint;
+};
+
+type OwnerRow = {
+  owner_id: string;
+  nickname: string | null;
+  keywords: string[];
+  bio: string | null;
+  profile_photo: string | null;
+  avg_star: number;
+  review_count: number;
+  trade_count: number;
 };
 
 const REFORMER_SELECT: Prisma.ownerSelect = {
@@ -169,47 +180,43 @@ export class ReformerModel {
 
     if (sort === 'rating') {
       const parts = cursorParts as RatingCursor | undefined;
-      const lastAvg = parts ? new Prisma.Decimal(parts[0]) : undefined;
-      const lastId = parts ? parts[1] : undefined;
+      const lastAvg = parts ? parts[0] : null;
+      const lastId = parts ? parts[1] : null;
 
-      const where: Prisma.ownerWhereInput = {
-        avg_star: { not: null },
-        ...(parts && {
-          OR: [
-            { avg_star: { lt: lastAvg } },
-            { AND: [{ avg_star: lastAvg }, { owner_id: { lt: lastId } }] }
-          ]
-        })
-      };
-
-      return await prisma.owner.findMany({
-        where,
-        orderBy: [{ avg_star: 'desc' }, { owner_id: 'desc' }],
-        take: limit + 1,
-        select: REFORMER_SELECT
-      });
+      // COALESCE로 null을 0으로 처리하여 정렬
+      return await prisma.$queryRaw<OwnerRow[]>`
+        SELECT owner_id, nickname, keywords, bio, profile_photo, 
+               COALESCE(avg_star, 0) as avg_star, 
+               COALESCE(review_count, 0) as review_count, 
+               COALESCE(trade_count, 0) as trade_count
+        FROM "owner"
+        WHERE (
+          ${lastAvg}::numeric IS NULL 
+          OR (COALESCE(avg_star, 0), owner_id) < (${lastAvg}::numeric, ${lastId}::uuid)
+        )
+        ORDER BY COALESCE(avg_star, 0) DESC, owner_id DESC
+        LIMIT ${limit + 1}
+      `;
     }
 
     const parts = cursorParts as TradeCursor | undefined;
-    const lastTrades = parts ? parts[0] : undefined;
-    const lastId = parts ? parts[1] : undefined;
+    const lastTrades = parts ? parts[0] : null;
+    const lastId = parts ? parts[1] : null;
 
-    const where: Prisma.ownerWhereInput = {
-      trade_count: { not: null },
-      ...(parts && {
-        OR: [
-          { trade_count: { lt: lastTrades } },
-          { AND: [{ trade_count: lastTrades }, { owner_id: { lt: lastId } }] }
-        ]
-      })
-    };
-
-    return await prisma.owner.findMany({
-      where,
-      orderBy: [{ trade_count: 'desc' }, { owner_id: 'desc' }],
-      take: limit + 1,
-      select: REFORMER_SELECT
-    });
+    // COALESCE로 null을 0으로 처리하여 정렬
+    return await prisma.$queryRaw<OwnerRow[]>`
+      SELECT owner_id, nickname, keywords, bio, profile_photo, 
+             COALESCE(avg_star, 0) as avg_star, 
+             COALESCE(review_count, 0) as review_count, 
+             COALESCE(trade_count, 0) as trade_count
+      FROM "owner"
+      WHERE (
+        ${lastTrades}::int IS NULL 
+        OR (COALESCE(trade_count, 0), owner_id) < (${lastTrades}::int, ${lastId}::uuid)
+      )
+      ORDER BY COALESCE(trade_count, 0) DESC, owner_id DESC
+      LIMIT ${limit + 1}
+    `;
   }
 
   public async countAll(): Promise<number> {


### PR DESCRIPTION
## 제목

<!-- 예: feat: 로그인 기능 구현 (#1) -->
 전체 리폼러탐색에 필드값이 null인 경우도 조회에 반영되도록 수정

## 개요

<!-- PR 목적과 변경 이유를 간단히 설명해주세요. -->

## 주요 변경 사항

- [ ] 정렬기준이 되는 필드의 값이 null인 경우 조회가 안되는 문제 해결

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #205 
- Relates to #205 

## 체크리스트

<!-- 최소 2명 코드리뷰 규칙을 반영한 체크리스트 -->

- [ ] 브랜치 네이밍 규칙 준수 (예: feat/1-login, fix/23-password-reset)
- [ ] 커밋 컨벤션 준수 (Type:Header Body Footer)
- [ ] 문서 반영 (README/API 명세/컨벤션/회의 노트 등)
- [ ] 보안 사항 확인 (비밀키/토큰 노출 없음, .env 사용)


